### PR TITLE
Add DeleteMonGroups to CtrlGroup interface

### DIFF
--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -66,6 +66,9 @@ type CtrlGroup interface {
 	// DeleteMonGroup deletes a monitoring group from the class.
 	DeleteMonGroup(name string) error
 
+	// DeleteMonGroups deletes all monitoring groups.
+	DeleteMonGroups() error
+
 	// GetMonGroup returns a specific monitoring group under the class
 	GetMonGroup(name string) (MonGroup, bool)
 
@@ -434,6 +437,15 @@ func (c *ctrlGroup) DeleteMonGroup(name string) error {
 
 	delete(c.monGroups, name)
 
+	return nil
+}
+
+func (c *ctrlGroup) DeleteMonGroups() error {
+	for name := range c.monGroups {
+		if err := c.DeleteMonGroup(name); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -344,6 +344,18 @@ partitions:
 		t.Errorf("unexpected error when checking directory of deleted mon group: %v", err)
 	}
 
+	for _, n := range []string{"foo", "bar", "baz"} {
+		if _, err := cls.CreateMonGroup(n, map[string]string{}); err != nil {
+			t.Errorf("creating mon group failed: %v", err)
+		}
+	}
+	if err := cls.DeleteMonGroups(); err != nil {
+		t.Errorf("unexpected error when deleting all mon groups: %v", err)
+	}
+	if mgs := cls.GetMonGroups(); len(mgs) != 0 {
+		t.Errorf("unexpected mon groups exist: %v", mgs)
+	}
+
 	// Verify assigning pids to monitor group
 	mgName = "test_group_2"
 	mockFs.initMockMonGroup("Guaranteed", mgName)


### PR DESCRIPTION
Deletes all monitoring groups from the ctrl group.