### PR TITLE
Stop blindly allocating all cache lines

### DIFF
--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -619,7 +619,7 @@ func (s partitionSet) resolveCacheIDRelative(id uint64, partitions []l3Partition
 	minCbmBits := info.l3MinCbmBits()
 	bitsTotal := uint64(info.l3CbmMask().lsbZero())
 	bitsAvailable := bitsTotal
-	for i, req := range reqs {
+	for _, req := range reqs {
 		percentageAvailable := bitsAvailable * 100 / bitsTotal
 
 		// This might happen e.g. if number of partitions would be greater
@@ -636,8 +636,8 @@ func (s partitionSet) resolveCacheIDRelative(id uint64, partitions []l3Partition
 		if numBits < minCbmBits {
 			numBits = minCbmBits
 		}
-		// Don't overflow, allocate all remaining bits to the last partition
-		if numBits > bitsAvailable || i == len(partitions)-1 {
+		// Don't overflow
+		if numBits > bitsAvailable {
 			numBits = bitsAvailable
 		}
 

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -867,6 +867,30 @@ partitions:
 		},
 		// Testcase
 		TC{
+			name: "L3 partial allocation",
+			fs:   "resctrl.nomb",
+			config: `
+partitions:
+  part-1:
+    l3Allocation:
+      all: "20%"
+      1: "40%"
+      2: "60%"
+      3: "80%"
+    classes:
+      class-1:
+`,
+			schemata: map[string]Schemata{
+				"class-1": Schemata{
+					l3: "0=f;1=ff;2=fff;3=ffff",
+				},
+				"SYSTEM_DEFAULT": Schemata{
+					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
+				},
+			},
+		},
+		// Testcase
+		TC{
 			name:        "L3 partition non-contiguous bitmask (fail)",
 			fs:          "resctrl.nomb",
 			configErrRe: `failed to parse L3 allocation request for partition "part-1": invalid cache bitmask "0x2f": more than one continuous block of ones`,


### PR DESCRIPTION
If a user specifies that only part of the cache lines should be
allocated for CRI workloads that's probably what she wants.