### PR TITLE
rdt/config: allocate cache lines up to requested total

### DIFF
--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -873,16 +873,27 @@ partitions:
 partitions:
   part-1:
     l3Allocation:
-      all: "20%"
-      1: "40%"
-      2: "60%"
-      3: "80%"
+      all: "21%"
+      1: "42%"
+      2: "63%"
+      3: "89%"
     classes:
       class-1:
+  part-2:
+    l3Allocation:
+      all: "29%"
+      1: "8%"
+      2: "19%"
+      3: "11%"
+    classes:
+      class-2:
 `,
 			schemata: map[string]Schemata{
 				"class-1": Schemata{
-					l3: "0=f;1=ff;2=fff;3=ffff",
+					l3: "0=f;1=ff;2=1fff;3=3ffff",
+				},
+				"class-2": Schemata{
+					l3: "0=3f0;1=300;2=e000;3=c0000",
 				},
 				"SYSTEM_DEFAULT": Schemata{
 					l3: "0=fffff;1=fffff;2=fffff;3=fffff",


### PR DESCRIPTION
Commit b302441eb1bfd08c92c4ef5d42537f6a7d71797c was too aggressive in
saving cache lines. We want to allocate up to the requested total
percentage of cache lines requested. Excess cache lines made available
by rounding errors in the previous passes are "donated" to the last to
be resolved (i.e. biggest) partition.