### PR TITLE
rdt: implement GetCPUs() and SetCPUs()

### DIFF
--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -87,6 +87,12 @@ type ResctrlGroup interface {
 	// AddPids assigns the given process ids to the group
 	AddPids(pids ...string) error
 
+	// GetCPUs returns the cpu ids associated with the group
+	GetCPUs() (string, error)
+
+	// SetCPUs associates the given cpu ids with the group
+	SetCPUs(cpus ...string) error
+
 	// GetMonData retrieves the monitoring data of the group
 	GetMonData() MonData
 }
@@ -640,6 +646,27 @@ func (r *resctrlGroup) AddPids(pids ...string) error {
 				return rdtError("failed to assign processes %v to class %q: %v", pids, r.name, rdt.cmdError(err))
 			}
 		}
+	}
+	return nil
+}
+
+func (r *resctrlGroup) GetCPUs() (string, error) {
+	data, err := rdt.readRdtFile(r.relPath("cpus_list"))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func (r *resctrlGroup) SetCPUs(cpus ...string) error {
+	f, err := os.OpenFile(r.path("cpus_list"), os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(strings.Join(cpus, ",")); err != nil {
+		return rdtError("failed to associate cpus %v to class %q: %v", cpus, r.name, rdt.cmdError(err))
 	}
 	return nil
 }


### PR DESCRIPTION
Functionality for associating CPUs with classes. Under the hood
goresctrl will write the given CPU ids to the "cpus_list" file of the
corresponding resctrl group.

The hierarchy between task and cpu lists is as follows (imposed by the
resctrl filesystem):
1. If a process PID is in the tasks file of a non-root class then that
   class is in effect
2. Else, if a process is running on a CPU that is associated with a class,
   then this class is in effect
3. Else the root class is in effect