### PR TITLE
rdt: separate log wrapper to its own package

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Intel Corporation
+Copyright 2019-2021 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rdt
+package log
 
 import (
 	"fmt"
@@ -32,6 +32,7 @@ type Logger interface {
 	Fatal(format string, v ...interface{})
 	DebugBlock(prefix, format string, v ...interface{})
 	InfoBlock(prefix, format string, v ...interface{})
+	Prefix() string
 }
 
 type logger struct {
@@ -83,4 +84,8 @@ func (l *logger) blockPrint(levelPrefix, linePrefix, format string, v ...interfa
 
 	p := strings.Repeat(" ", len(l.Logger.Prefix())+len(levelPrefix)) + linePrefix
 	l.Logger.Print(strings.Join(lines, "\n"+p))
+}
+
+func (l *logger) Prefix() string {
+	return l.Logger.Prefix()
 }

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"syscall"
 
+	grclog "github.com/intel/goresctrl/pkg/log"
 	"github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -38,7 +39,7 @@ const (
 )
 
 type control struct {
-	Logger
+	grclog.Logger
 
 	resctrlGroupPrefix string
 	conf               config
@@ -46,7 +47,7 @@ type control struct {
 	classes            map[string]*ctrlGroup
 }
 
-var log Logger = NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt ] ", 0))
+var log grclog.Logger = grclog.NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt ] ", 0))
 
 var info *resctrlInfo
 
@@ -142,7 +143,7 @@ type resctrlGroup struct {
 
 // SetLogger sets the logger instance to be used by the package. This function
 // may be called even before Initialize().
-func SetLogger(l Logger) {
+func SetLogger(l grclog.Logger) {
 	log = l
 	if rdt != nil {
 		rdt.setLogger(l)
@@ -259,7 +260,7 @@ func (c *control) getMonFeatures() map[MonResource][]string {
 	return ret
 }
 
-func (c *control) setLogger(l Logger) {
+func (c *control) setLogger(l grclog.Logger) {
 	c.Logger = l
 }
 

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	grclog "github.com/intel/goresctrl/pkg/log"
 	"github.com/intel/goresctrl/pkg/utils"
 	testdata "github.com/intel/goresctrl/test/data"
 )
@@ -177,7 +178,7 @@ partitions:
 	//
 	// 1. test uninitialized interface
 	//
-	SetLogger(NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test-1 ] ", 0)))
+	SetLogger(grclog.NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test-1 ] ", 0)))
 
 	if err := SetConfig(&Config{}, false); err == nil {
 		t.Errorf("setting config on uninitialized rdt succeeded unexpectedly")
@@ -233,8 +234,8 @@ partitions:
 	}
 
 	// Check that SetLogger() takes effect in the control interface, too
-	SetLogger(NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test-2 ] ", 0)))
-	if p := rdt.Logger.(*logger).Prefix(); p != "[ rdt-test-2 ] " {
+	SetLogger(grclog.NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test-2 ] ", 0)))
+	if p := rdt.Logger.Prefix(); p != "[ rdt-test-2 ] " {
 		t.Errorf("unexpected logger prefix %q", p)
 	}
 


### PR DESCRIPTION
This enables blockio to use the same log wrapper package
without duplicating the wrapper.