### PR TITLE
cgroups: add the cgroup filesystem interface

### DIFF
--- a/pkg/cgroups/cgroupblkio.go
+++ b/pkg/cgroups/cgroupblkio.go
@@ -1,0 +1,313 @@
+// Copyright 2020-2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// cgroups blkio parameter filenames.
+var blkioWeightFiles = []string{"blkio.bfq.weight", "blkio.weight"}
+var blkioWeightDeviceFiles = []string{"blkio.bfq.weight_device", "blkio.weight_device"}
+var blkioThrottleReadBpsFiles = []string{"blkio.throttle.read_bps_device"}
+var blkioThrottleWriteBpsFiles = []string{"blkio.throttle.write_bps_device"}
+var blkioThrottleReadIOPSFiles = []string{"blkio.throttle.read_iops_device"}
+var blkioThrottleWriteIOPSFiles = []string{"blkio.throttle.write_iops_device"}
+
+// OciBlockIOParameters contains OCI standard configuration of cgroups blkio parameters.
+//
+// Effects of Weight and Rate values in SetBlkioParameters():
+// Value  |  Effect
+// -------+-------------------------------------------------------------------
+//    -1  |  Do not write to cgroups, value is missing
+//     0  |  Write to cgroups, will remove the setting as specified in cgroups blkio interface
+//  other |  Write to cgroups, sets the value
+type OciBlockIOParameters struct {
+	Weight                  int64
+	WeightDevice            OciDeviceWeights
+	ThrottleReadBpsDevice   OciDeviceRates
+	ThrottleWriteBpsDevice  OciDeviceRates
+	ThrottleReadIOPSDevice  OciDeviceRates
+	ThrottleWriteIOPSDevice OciDeviceRates
+}
+
+// OciDeviceWeight contains values for
+// - blkio.[io-scheduler].weight
+type OciDeviceWeight struct {
+	Major  int64
+	Minor  int64
+	Weight int64
+}
+
+// OciDeviceRate contains values for
+// - blkio.throttle.read_bps_device
+// - blkio.throttle.write_bps_device
+// - blkio.throttle.read_iops_device
+// - blkio.throttle.write_iops_device
+type OciDeviceRate struct {
+	Major int64
+	Minor int64
+	Rate  int64
+}
+
+// OciDeviceWeights contains weights for devices
+type OciDeviceWeights []OciDeviceWeight
+
+// OciDeviceRates contains throttling rates for devices
+type OciDeviceRates []OciDeviceRate
+
+// OciDeviceParameters interface provides functions common to OciDeviceWeights and OciDeviceRates
+type OciDeviceParameters interface {
+	Append(maj, min, val int64)
+	Update(maj, min, val int64)
+}
+
+// Append appends (major, minor, value) to OciDeviceWeights slice.
+func (w *OciDeviceWeights) Append(maj, min, val int64) {
+	*w = append(*w, OciDeviceWeight{Major: maj, Minor: min, Weight: val})
+}
+
+// Append appends (major, minor, value) to OciDeviceRates slice.
+func (r *OciDeviceRates) Append(maj, min, val int64) {
+	*r = append(*r, OciDeviceRate{Major: maj, Minor: min, Rate: val})
+}
+
+// Update updates device weight in OciDeviceWeights slice, or appends it if not found.
+func (w *OciDeviceWeights) Update(maj, min, val int64) {
+	for index, devWeight := range *w {
+		if devWeight.Major == maj && devWeight.Minor == min {
+			(*w)[index].Weight = val
+			return
+		}
+	}
+	w.Append(maj, min, val)
+}
+
+// Update updates device rate in OciDeviceRates slice, or appends it if not found.
+func (r *OciDeviceRates) Update(maj, min, val int64) {
+	for index, devRate := range *r {
+		if devRate.Major == maj && devRate.Minor == min {
+			(*r)[index].Rate = val
+			return
+		}
+	}
+	r.Append(maj, min, val)
+}
+
+// NewOciBlockIOParameters creates new OciBlockIOParameters instance.
+func NewOciBlockIOParameters() OciBlockIOParameters {
+	return OciBlockIOParameters{
+		Weight: -1,
+	}
+}
+
+// NewOciDeviceWeight creates new OciDeviceWeight instance.
+func NewOciDeviceWeight() OciDeviceWeight {
+	return OciDeviceWeight{
+		Major:  -1,
+		Minor:  -1,
+		Weight: -1,
+	}
+}
+
+// NewOciDeviceRate creates new OciDeviceRate instance.
+func NewOciDeviceRate() OciDeviceRate {
+	return OciDeviceRate{
+		Major: -1,
+		Minor: -1,
+		Rate:  -1,
+	}
+}
+
+type devMajMin struct {
+	Major int64
+	Minor int64
+}
+
+// ResetBlkioParameters adds new, changes existing and removes missing blockIO parameters in cgroupsDir
+func ResetBlkioParameters(groupDir string, blockIO OciBlockIOParameters) error {
+	var errors *multierror.Error
+	oldBlockIO, getErr := GetBlkioParameters(groupDir)
+	errors = multierror.Append(errors, getErr)
+	newBlockIO := NewOciBlockIOParameters()
+	newBlockIO.Weight = blockIO.Weight
+	newBlockIO.WeightDevice = resetDevWeights(oldBlockIO.WeightDevice, blockIO.WeightDevice)
+	newBlockIO.ThrottleReadBpsDevice = resetDevRates(oldBlockIO.ThrottleReadBpsDevice, blockIO.ThrottleReadBpsDevice)
+	newBlockIO.ThrottleWriteBpsDevice = resetDevRates(oldBlockIO.ThrottleWriteBpsDevice, blockIO.ThrottleWriteBpsDevice)
+	newBlockIO.ThrottleReadIOPSDevice = resetDevRates(oldBlockIO.ThrottleReadIOPSDevice, blockIO.ThrottleReadIOPSDevice)
+	newBlockIO.ThrottleWriteIOPSDevice = resetDevRates(oldBlockIO.ThrottleWriteIOPSDevice, blockIO.ThrottleWriteIOPSDevice)
+	errors = multierror.Append(errors, SetBlkioParameters(groupDir, newBlockIO))
+	return errors.ErrorOrNil()
+}
+
+// resetDevWeights adds wanted weight parameters to new and resets unwanted weights
+func resetDevWeights(old, wanted []OciDeviceWeight) []OciDeviceWeight {
+	new := []OciDeviceWeight{}
+	seenDev := map[devMajMin]bool{}
+	for _, wdp := range wanted {
+		seenDev[devMajMin{wdp.Major, wdp.Minor}] = true
+		new = append(new, wdp)
+	}
+	for _, wdp := range old {
+		if !seenDev[devMajMin{wdp.Major, wdp.Minor}] {
+			new = append(new, OciDeviceWeight{wdp.Major, wdp.Minor, 0})
+		}
+	}
+	return new
+}
+
+// resetDevRates adds wanted rate parameters to new and resets unwanted rates
+func resetDevRates(old, wanted []OciDeviceRate) []OciDeviceRate {
+	new := []OciDeviceRate{}
+	seenDev := map[devMajMin]bool{}
+	for _, rdp := range wanted {
+		new = append(new, rdp)
+		seenDev[devMajMin{rdp.Major, rdp.Minor}] = true
+	}
+	for _, rdp := range old {
+		if !seenDev[devMajMin{rdp.Major, rdp.Minor}] {
+			new = append(new, OciDeviceRate{rdp.Major, rdp.Minor, 0})
+		}
+	}
+	return new
+}
+
+// GetBlkioParameters returns OCI BlockIO parameters from files in cgroups blkio controller directory.
+func GetBlkioParameters(group string) (OciBlockIOParameters, error) {
+	var errors *multierror.Error
+	blockIO := NewOciBlockIOParameters()
+
+	errors = multierror.Append(errors, readWeight(group, blkioWeightFiles, &blockIO.Weight))
+	errors = multierror.Append(errors, readOciDeviceParameters(group, blkioWeightDeviceFiles, &blockIO.WeightDevice))
+	errors = multierror.Append(errors, readOciDeviceParameters(group, blkioThrottleReadBpsFiles, &blockIO.ThrottleReadBpsDevice))
+	errors = multierror.Append(errors, readOciDeviceParameters(group, blkioThrottleWriteBpsFiles, &blockIO.ThrottleWriteBpsDevice))
+	errors = multierror.Append(errors, readOciDeviceParameters(group, blkioThrottleReadIOPSFiles, &blockIO.ThrottleReadIOPSDevice))
+	errors = multierror.Append(errors, readOciDeviceParameters(group, blkioThrottleWriteIOPSFiles, &blockIO.ThrottleWriteIOPSDevice))
+	return blockIO, errors.ErrorOrNil()
+}
+
+// readWeight parses int64 from a cgroups entry
+func readWeight(groupDir string, filenames []string, rv *int64) error {
+	contents, err := readFirstFile(groupDir, filenames)
+	if err != nil {
+		return err
+	}
+	parsed, err := strconv.ParseInt(strings.TrimSuffix(contents, "\n"), 10, 64)
+	if err != nil {
+		return fmt.Errorf("parsing weight from %#v found in %v failed: %w", contents, filenames, err)
+	}
+	*rv = parsed
+	return nil
+}
+
+// readOciDeviceParameters parses device lines used for weights and throttling rates
+func readOciDeviceParameters(groupDir string, filenames []string, params OciDeviceParameters) error {
+	var errors *multierror.Error
+	contents, err := readFirstFile(groupDir, filenames)
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(contents, "\n") {
+		// Device weight files may have "default NNN" line at the beginning. Skip it.
+		if line == "" || strings.HasPrefix(line, "default ") {
+			continue
+		}
+		// Expect syntax MAJOR:MINOR VALUE
+		devVal := strings.Split(line, " ")
+		if len(devVal) != 2 {
+			errors = multierror.Append(errors, fmt.Errorf("invalid line %q, single space expected", line))
+			continue
+		}
+		majMin := strings.Split(devVal[0], ":")
+		if len(majMin) != 2 {
+			errors = multierror.Append(errors, fmt.Errorf("invalid line %q, single colon expected before space", line))
+			continue
+		}
+		major, majErr := strconv.ParseInt(majMin[0], 10, 64)
+		minor, minErr := strconv.ParseInt(majMin[1], 10, 64)
+		value, valErr := strconv.ParseInt(devVal[1], 10, 64)
+		if majErr != nil || minErr != nil || valErr != nil {
+			errors = multierror.Append(errors, fmt.Errorf("invalid number when parsing \"major:minor value\" from \"%s:%s %s\"", majMin[0], majMin[1], devVal[1]))
+			continue
+		}
+		params.Append(major, minor, value)
+	}
+	return errors.ErrorOrNil()
+}
+
+// readFirstFile returns contents of the first successfully read entry.
+func readFirstFile(groupDir string, filenames []string) (string, error) {
+	var errors *multierror.Error
+	// If reading all the files fails, return list of read errors.
+	for _, filename := range filenames {
+		content, err := Blkio.Group(groupDir).Read(filename)
+		if err == nil {
+			return content, nil
+		}
+		errors = multierror.Append(errors, err)
+	}
+	err := errors.ErrorOrNil()
+	if err != nil {
+		return "", fmt.Errorf("could not read any of files %q: %w", filenames, err)
+	}
+	return "", nil
+}
+
+// SetBlkioParameters writes OCI BlockIO parameters to files in cgroups blkio contoller directory.
+func SetBlkioParameters(group string, blockIO OciBlockIOParameters) error {
+	var errors *multierror.Error
+	if blockIO.Weight >= 0 {
+		errors = multierror.Append(errors, writeFirstFile(group, blkioWeightFiles, "%d", blockIO.Weight))
+	}
+	for _, wd := range blockIO.WeightDevice {
+		errors = multierror.Append(errors, writeFirstFile(group, blkioWeightDeviceFiles, "%d:%d %d", wd.Major, wd.Minor, wd.Weight))
+	}
+	for _, rd := range blockIO.ThrottleReadBpsDevice {
+		errors = multierror.Append(errors, writeFirstFile(group, blkioThrottleReadBpsFiles, "%d:%d %d", rd.Major, rd.Minor, rd.Rate))
+	}
+	for _, rd := range blockIO.ThrottleWriteBpsDevice {
+		errors = multierror.Append(errors, writeFirstFile(group, blkioThrottleWriteBpsFiles, "%d:%d %d", rd.Major, rd.Minor, rd.Rate))
+	}
+	for _, rd := range blockIO.ThrottleReadIOPSDevice {
+		errors = multierror.Append(errors, writeFirstFile(group, blkioThrottleReadIOPSFiles, "%d:%d %d", rd.Major, rd.Minor, rd.Rate))
+	}
+	for _, rd := range blockIO.ThrottleWriteIOPSDevice {
+		errors = multierror.Append(errors, writeFirstFile(group, blkioThrottleWriteIOPSFiles, "%d:%d %d", rd.Major, rd.Minor, rd.Rate))
+	}
+	return errors.ErrorOrNil()
+}
+
+// writeFirstFile writes content to the first existing file in the list under groupDir.
+func writeFirstFile(groupDir string, filenames []string, format string, args ...interface{}) error {
+	var errors *multierror.Error
+	// Returns list of errors from writes, list of single error due to all filenames missing or nil on success.
+	for _, filename := range filenames {
+		if err := Blkio.Group(groupDir).Write(filename, format, args...); err != nil {
+			errors = multierror.Append(errors, err)
+			continue
+		}
+		return nil
+	}
+	err := errors.ErrorOrNil()
+	if err != nil {
+		data := fmt.Sprintf(format, args...)
+		return fmt.Errorf("writing all files %v failed, errors: %w, content %q", filenames, err, data)
+	}
+	return nil
+}

--- a/pkg/cgroups/cgroupblkio_test.go
+++ b/pkg/cgroups/cgroupblkio_test.go
@@ -1,0 +1,466 @@
+// Copyright 2020-2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"bytes"
+	"io"
+	"syscall"
+	"testing"
+
+	"github.com/intel/goresctrl/pkg/testutils"
+)
+
+func TestUpdateAppend(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		inputMajMinVals         [][]int64
+		inputItem               []int64
+		expectedMajMinVal       [][]int64
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:              "update empty list",
+			inputItem:         []int64{1, 2, 3},
+			expectedMajMinVal: [][]int64{{1, 2, 3}},
+		},
+		{
+			name:              "update appends non-existing element",
+			inputMajMinVals:   [][]int64{{10, 20, 30}, {40, 50, 60}},
+			inputItem:         []int64{1, 2, 3},
+			expectedMajMinVal: [][]int64{{10, 20, 30}, {40, 50, 60}, {1, 2, 3}},
+		},
+		{
+			name:              "update the first existing element",
+			inputMajMinVals:   [][]int64{{10, 20, 30}, {40, 50, 60}, {40, 50, 60}},
+			inputItem:         []int64{40, 50, 66},
+			expectedMajMinVal: [][]int64{{10, 20, 30}, {40, 50, 66}, {40, 50, 60}},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			devWeights := OciDeviceWeights{}
+			devRates := OciDeviceRates{}
+			expDevWeights := OciDeviceWeights{}
+			expDevRates := OciDeviceRates{}
+			for _, item := range tc.inputMajMinVals {
+				devWeights.Append(item[0], item[1], item[2])
+				devRates.Append(item[0], item[1], item[2])
+			}
+			devWeights.Update(tc.inputItem[0], tc.inputItem[1], tc.inputItem[2])
+			devRates.Update(tc.inputItem[0], tc.inputItem[1], tc.inputItem[2])
+			for _, item := range tc.expectedMajMinVal {
+				expDevWeights = append(expDevWeights, OciDeviceWeight{item[0], item[1], item[2]})
+				expDevRates = append(expDevRates, OciDeviceRate{item[0], item[1], item[2]})
+			}
+			testutils.VerifyDeepEqual(t, "device weights", expDevWeights, devWeights)
+			testutils.VerifyDeepEqual(t, "device rates", expDevRates, devRates)
+		})
+	}
+}
+
+var fsBlkioUtFiles map[string]mockFile = map[string]mockFile{
+	mountDir + "/blkio/mockpods/clean/blkio.bfq.weight":                 {data: []byte("100\n")},
+	mountDir + "/blkio/mockpods/clean/blkio.bfq.weight_device":          {},
+	mountDir + "/blkio/mockpods/clean/blkio.throttle.read_bps_device":   {},
+	mountDir + "/blkio/mockpods/clean/blkio.throttle.write_bps_device":  {},
+	mountDir + "/blkio/mockpods/clean/blkio.throttle.read_iops_device":  {},
+	mountDir + "/blkio/mockpods/clean/blkio.throttle.write_iops_device": {},
+
+	mountDir + "/blkio/mockpods/no-blkio-bfq-weight/blkio.weight": {data: []byte("100\n")},
+
+	mountDir + "/blkio/mockpods/reset/blkio.bfq.weight":                 {data: []byte("200\n")},
+	mountDir + "/blkio/mockpods/reset/blkio.bfq.weight_device":          {data: []byte("default 200\n1:2 3\n4:5 6\n")},
+	mountDir + "/blkio/mockpods/reset/blkio.throttle.read_bps_device":   {data: []byte("11:12 13\n14:15 16\n")},
+	mountDir + "/blkio/mockpods/reset/blkio.throttle.write_bps_device":  {data: []byte("21:22 23\n")},
+	mountDir + "/blkio/mockpods/reset/blkio.throttle.read_iops_device":  {data: []byte("31:32 33\n")},
+	mountDir + "/blkio/mockpods/reset/blkio.throttle.write_iops_device": {data: []byte("41:42 43\n")},
+
+	mountDir + "/blkio/mockpods/merge/blkio.bfq.weight":                 {data: []byte("200\n")},
+	mountDir + "/blkio/mockpods/merge/blkio.bfq.weight_device":          {data: []byte("default 200\n1:2 3\n4:5 6\n7:8 9")},
+	mountDir + "/blkio/mockpods/merge/blkio.throttle.read_bps_device":   {data: []byte("11:12 13\n14:15 16\n")},
+	mountDir + "/blkio/mockpods/merge/blkio.throttle.write_bps_device":  {data: []byte("21:22 23\n24:25 26\n")},
+	mountDir + "/blkio/mockpods/merge/blkio.throttle.read_iops_device":  {data: []byte("31:32 33\n331:332 333\n")},
+	mountDir + "/blkio/mockpods/merge/blkio.throttle.write_iops_device": {data: []byte("41:42 43\n441:442 443\n")},
+
+	// parseok:
+	// test weight without linefeed
+	// test weight_device file with real "default" line
+	// test parsing two lines and skipping empty lines
+	// test single line file
+	// test single line, missing LF at the end
+	// test small and large values
+	mountDir + "/blkio/parseok/blkio.bfq.weight":                 {data: []byte("1")},
+	mountDir + "/blkio/parseok/blkio.bfq.weight_device":          {data: []byte("default 10\n1:2 3\n")},
+	mountDir + "/blkio/parseok/blkio.throttle.read_bps_device":   {data: []byte("\n11:22 33\n\n111:222 333\n")},
+	mountDir + "/blkio/parseok/blkio.throttle.write_bps_device":  {data: []byte("1111:2222 3333\n")},
+	mountDir + "/blkio/parseok/blkio.throttle.read_iops_device":  {data: []byte("11111:22222 33333")},
+	mountDir + "/blkio/parseok/blkio.throttle.write_iops_device": {data: []byte("0:0 0\n4294967296:4294967297 9223372036854775807\n")},
+
+	// parse-err:
+	// weight: not a number
+	// weight_device: test bad line in the middle
+	// read_bps_device: test no spaces
+	// write_bps_device: test too many spaces
+	// read_iobps_device: test no colons
+	// write_iobps_device: test missing number
+	mountDir + "/blkio/parse-err/blkio.bfq.weight":                 {data: []byte("xyz")},
+	mountDir + "/blkio/parse-err/blkio.bfq.weight_device":          {data: []byte("default 10\n1:2 3\nbad\n4:5 6\n")},
+	mountDir + "/blkio/parse-err/blkio.throttle.read_bps_device":   {data: []byte("11:22:33")},
+	mountDir + "/blkio/parse-err/blkio.throttle.write_bps_device":  {data: []byte("1111 2222 3333 \n")},
+	mountDir + "/blkio/parse-err/blkio.throttle.read_iops_device":  {data: []byte("1111122222 33333")},
+	mountDir + "/blkio/parse-err/blkio.throttle.write_iops_device": {data: []byte("0: 0\n")},
+
+	mountDir + "/blkio/write-enodev/blkio.bfq.weight":                 {write: func([]byte) (int, error) { return 0, syscall.ENODEV }},
+	mountDir + "/blkio/write-enodev/blkio.bfq.weight_device":          {write: func([]byte) (int, error) { return 0, syscall.ENODEV }},
+	mountDir + "/blkio/write-enodev/blkio.throttle.read_bps_device":   {write: func([]byte) (int, error) { return 0, syscall.ENODEV }},
+	mountDir + "/blkio/write-enodev/blkio.throttle.write_bps_device":  {write: func([]byte) (int, error) { return 0, syscall.ENODEV }},
+	mountDir + "/blkio/write-enodev/blkio.throttle.read_iops_device":  {write: func([]byte) (int, error) { return 0, syscall.ENODEV }},
+	mountDir + "/blkio/write-enodev/blkio.throttle.write_iops_device": {write: func([]byte) (int, error) { return 0, syscall.ENODEV }},
+}
+
+// TestResetBlkioParameters: unit test for ResetBlkioParameters()
+func TestResetBlkioParameters(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		fsi                     fsiIface
+		cntnrDir                string
+		blockIO                 OciBlockIOParameters
+		expectedFsWrites        map[string][][]byte
+		expectedBlockIO         *OciBlockIOParameters
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:     "write to clean cgroups",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "mockpods/clean",
+			blockIO: OciBlockIOParameters{
+				Weight:                  222,
+				WeightDevice:            OciDeviceWeights{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 12, 13}, {111, 112, 113}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{21, 22, 23}, {221, 222, 223}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{31, 32, 33}, {331, 332, 333}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{41, 42, 43}, {441, 442, 443}},
+			},
+			expectedFsWrites: map[string][][]byte{
+				mountDir + "/blkio/mockpods/clean/blkio.bfq.weight":                 {[]byte("222")},
+				mountDir + "/blkio/mockpods/clean/blkio.bfq.weight_device":          {[]byte("1:2 3"), []byte("4:5 6"), []byte("7:8 9")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.read_bps_device":   {[]byte("11:12 13"), []byte("111:112 113")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.write_bps_device":  {[]byte("21:22 23"), []byte("221:222 223")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.read_iops_device":  {[]byte("31:32 33"), []byte("331:332 333")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.write_iops_device": {[]byte("41:42 43"), []byte("441:442 443")},
+			},
+		},
+		{
+			name:     "reset all existing",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "mockpods/reset",
+			blockIO:  NewOciBlockIOParameters(),
+			expectedFsWrites: map[string][][]byte{
+				mountDir + "/blkio/mockpods/reset/blkio.bfq.weight_device":          {[]byte("1:2 0"), []byte("4:5 0")},
+				mountDir + "/blkio/mockpods/reset/blkio.throttle.read_bps_device":   {[]byte("11:12 0"), []byte("14:15 0")},
+				mountDir + "/blkio/mockpods/reset/blkio.throttle.write_bps_device":  {[]byte("21:22 0")},
+				mountDir + "/blkio/mockpods/reset/blkio.throttle.read_iops_device":  {[]byte("31:32 0")},
+				mountDir + "/blkio/mockpods/reset/blkio.throttle.write_iops_device": {[]byte("41:42 0")},
+			},
+		},
+		{
+			name:     "merge",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "mockpods/merge",
+			blockIO: OciBlockIOParameters{
+				Weight:                  80,
+				WeightDevice:            OciDeviceWeights{{1, 2, 1113}, {7, 8, 9}},       // drop middle, update first, keep last
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 12, 13}},                    // keep the first entry
+				ThrottleWriteBpsDevice:  OciDeviceRates{{24, 25, 26}},                    // keep the last entry
+				ThrottleReadIOPSDevice:  OciDeviceRates{{31, 32, 33}, {331, 332, 333}},   // keep all
+				ThrottleWriteIOPSDevice: OciDeviceRates{{41, 42, 430}, {441, 442, 4430}}, // change all
+			},
+			expectedFsWrites: map[string][][]byte{
+				mountDir + "/blkio/mockpods/merge/blkio.bfq.weight":                 {[]byte("80")},
+				mountDir + "/blkio/mockpods/merge/blkio.bfq.weight_device":          {[]byte("1:2 1113"), []byte("7:8 9"), []byte("4:5 0")},
+				mountDir + "/blkio/mockpods/merge/blkio.throttle.read_bps_device":   {[]byte("11:12 13"), []byte("14:15 0")},
+				mountDir + "/blkio/mockpods/merge/blkio.throttle.write_bps_device":  {[]byte("24:25 26"), []byte("21:22 0")},
+				mountDir + "/blkio/mockpods/merge/blkio.throttle.read_iops_device":  {[]byte("31:32 33"), []byte("331:332 333")},
+				mountDir + "/blkio/mockpods/merge/blkio.throttle.write_iops_device": {[]byte("41:42 430"), []byte("441:442 4430")},
+			},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsi = tc.fsi
+			err := ResetBlkioParameters(tc.cntnrDir, tc.blockIO)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			validateWriteHistory(t, tc.expectedFsWrites, fsi.(*fsMock).files)
+		})
+	}
+}
+
+// validateWriteHistory compares expected writes to filesystem to all
+// observed writes.
+func validateWriteHistory(t *testing.T, expected map[string][][]byte, filesystem map[string]*mockFile) {
+	for expFilename, expWrites := range expected {
+		mf, ok := filesystem[expFilename]
+		if !ok {
+			t.Errorf("expected writes to %q, but file is missing", expFilename)
+			return
+		}
+		obsWrites := mf.writeHistory
+		if len(expWrites) != len(obsWrites) {
+			t.Errorf("unexpected number of writes to %q: expected %v, observed %v", expFilename, expWrites, obsWrites)
+			return
+		}
+		for i, expWrite := range expWrites {
+			if !bytes.Equal(expWrite, obsWrites[i]) {
+				t.Errorf("write at index %d differs: expected %v, observed %v", i, expWrites, obsWrites)
+			}
+		}
+	}
+	for obsFilename, mf := range filesystem {
+		if mf.writeHistory != nil {
+			if _, ok := expected[obsFilename]; !ok {
+				t.Errorf("writes to unexpected file %q, observed: %v", obsFilename, mf.writeHistory)
+			}
+		}
+	}
+}
+
+// TestGetBlkioParameters: unit test for GetBlkioParameters()
+func TestGetBlkioParameters(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		fsi                     fsiIface
+		fsFuncs                 map[string]mockFile
+		cntnrDir                string
+		readsFail               int
+		fsContent               map[string]string
+		expectedBlockIO         *OciBlockIOParameters
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name: "all clean and empty",
+			fsi:  NewFsiMock(fsBlkioUtFiles),
+			fsFuncs: map[string]mockFile{
+				// reuse clean directory, but force weight file empty
+				mountDir + "/blkio/mockpods/clean/blkio.bfq.weight": {
+					read: func([]byte) (int, error) { return 0, io.EOF },
+				},
+			},
+			cntnrDir:                "mockpods/clean",
+			expectedBlockIO:         &OciBlockIOParameters{Weight: -1},
+			expectedErrorCount:      1, // weight is not expected to be empty
+			expectedErrorSubstrings: []string{"parsing weight"},
+		},
+		{
+			name:     "everything defined",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "/parseok",
+			expectedBlockIO: &OciBlockIOParameters{
+				Weight:                  1,
+				WeightDevice:            OciDeviceWeights{{1, 2, 3}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 22, 33}, {111, 222, 333}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{1111, 2222, 3333}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{11111, 22222, 33333}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{0, 0, 0}, {4294967296, 4294967297, 9223372036854775807}},
+			},
+		},
+		{
+			name:                    "test bad files",
+			fsi:                     NewFsiMock(fsBlkioUtFiles),
+			cntnrDir:                "/parse-err",
+			expectedErrorCount:      6,
+			expectedErrorSubstrings: []string{"bad", "xyz", "11:22:33", "1111 2222 3333 ", "1111122222 33333", "0: 0"},
+			expectedBlockIO: &OciBlockIOParameters{
+				Weight:       -1,
+				WeightDevice: OciDeviceWeights{{1, 2, 3}, {4, 5, 6}},
+			},
+		},
+		{
+			name:               "all files missing",
+			fsi:                NewFsiMock(fsBlkioUtFiles),
+			cntnrDir:           "/this/container/does/not/exist",
+			expectedBlockIO:    &OciBlockIOParameters{Weight: -1},
+			expectedErrorCount: 6,
+			expectedErrorSubstrings: []string{
+				"file not found",
+				"blkio.bfq.weight",
+				"blkio.bfq.weight_device",
+				"blkio.throttle.read_bps_device",
+				"blkio.throttle.write_bps_device",
+				"blkio.throttle.read_iops_device",
+				"blkio.throttle.write_iops_device",
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsi = tc.fsi
+			overrideFsFuncs(fsi.(*fsMock), tc.fsFuncs)
+			blockIO, err := GetBlkioParameters(tc.cntnrDir)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			if tc.expectedBlockIO != nil {
+				testutils.VerifyDeepEqual(t, "blockio parameters", *tc.expectedBlockIO, blockIO)
+			}
+		})
+	}
+}
+
+// overrideFsFuncs (re)sets user overrides of file-specific functions
+// in the mock filesystem.
+func overrideFsFuncs(fsm *fsMock, fsFuncs map[string]mockFile) {
+	for filename, mf := range fsFuncs {
+		if mf.open != nil {
+			fsm.files[filename].open = mf.open
+		}
+		if mf.read != nil {
+			fsm.files[filename].read = mf.read
+		}
+		if mf.write != nil {
+			fsm.files[filename].write = mf.write
+		}
+	}
+}
+
+// TestSetBlkioParameters: unit test for SetBlkioParameters()
+func TestSetBlkioParameters(t *testing.T) {
+	tcases := []struct {
+		name                    string
+		fsi                     fsiIface
+		fsFuncs                 map[string]mockFile
+		cntnrDir                string
+		blockIO                 OciBlockIOParameters
+		writesFail              int
+		expectedFsWrites        map[string][][]byte
+		expectedErrorCount      int
+		expectedErrorSubstrings []string
+	}{
+		{
+			name:     "write full OCI struct",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "/mockpods/clean",
+			blockIO: OciBlockIOParameters{
+				Weight:                  10,
+				WeightDevice:            OciDeviceWeights{{Major: 1, Minor: 2, Weight: 3}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{Major: 11, Minor: 12, Rate: 13}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{Major: 21, Minor: 22, Rate: 23}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{Major: 31, Minor: 32, Rate: 33}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{Major: 41, Minor: 42, Rate: 43}},
+			},
+			expectedFsWrites: map[string][][]byte{
+				mountDir + "/blkio/mockpods/clean/blkio.bfq.weight":                 {[]byte("10")},
+				mountDir + "/blkio/mockpods/clean/blkio.bfq.weight_device":          {[]byte("1:2 3")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.read_bps_device":   {[]byte("11:12 13")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.write_bps_device":  {[]byte("21:22 23")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.read_iops_device":  {[]byte("31:32 33")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.write_iops_device": {[]byte("41:42 43")},
+			},
+		},
+		{
+			name:     "write empty struct",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "/mockpods/clean",
+			blockIO:  OciBlockIOParameters{},
+			expectedFsWrites: map[string][][]byte{
+				mountDir + "/blkio/mockpods/clean/blkio.bfq.weight": {[]byte("0")},
+			},
+		},
+		{
+			name:     "multidevice weight and throttling, no weight write on -1",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "/mockpods/clean",
+			blockIO: OciBlockIOParameters{
+				Weight:                  -1,
+				WeightDevice:            OciDeviceWeights{{1, 2, 3}, {4, 5, 6}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{11, 12, 13}, {111, 112, 113}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{21, 22, 23}, {221, 222, 223}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{31, 32, 33}, {331, 332, 333}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{41, 42, 43}, {441, 442, 443}},
+			},
+			expectedFsWrites: map[string][][]byte{
+				mountDir + "/blkio/mockpods/clean/blkio.bfq.weight_device":          {[]byte("1:2 3"), []byte("4:5 6")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.read_bps_device":   {[]byte("11:12 13"), []byte("111:112 113")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.write_bps_device":  {[]byte("21:22 23"), []byte("221:222 223")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.read_iops_device":  {[]byte("31:32 33"), []byte("331:332 333")},
+				mountDir + "/blkio/mockpods/clean/blkio.throttle.write_iops_device": {[]byte("41:42 43"), []byte("441:442 443")},
+			},
+		},
+		{
+			name:       "no bfq.weight",
+			fsi:        NewFsiMock(fsBlkioUtFiles),
+			cntnrDir:   "/mockpods/no-blkio-bfq-weight",
+			blockIO:    OciBlockIOParameters{Weight: 100},
+			writesFail: 1,
+			expectedFsWrites: map[string][][]byte{
+				mountDir + "/blkio/mockpods/no-blkio-bfq-weight/blkio.weight": {[]byte("100")},
+			},
+		},
+		{
+			name:     "all writes fail",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "write-enodev",
+			blockIO: OciBlockIOParameters{
+				Weight:                -1,
+				WeightDevice:          OciDeviceWeights{{1, 0, 100}},
+				ThrottleReadBpsDevice: OciDeviceRates{{11, 12, 13}},
+			},
+			expectedErrorCount: 2,
+			expectedErrorSubstrings: []string{
+				"\"1:0 100\"",
+				"\"11:12 13\"",
+				"\"blkio.bfq.weight_device\"",
+				"\"blkio.weight_device\"",
+				"read_bps_device",
+				"no such device",
+				"file not found",
+			},
+		},
+		{
+			name:     "all files missing",
+			fsi:      NewFsiMock(fsBlkioUtFiles),
+			cntnrDir: "/this/container/does/not/exist",
+			blockIO: OciBlockIOParameters{
+				Weight:                  10,
+				WeightDevice:            OciDeviceWeights{{Major: 1, Minor: 2, Weight: 3}},
+				ThrottleReadBpsDevice:   OciDeviceRates{{Major: 11, Minor: 12, Rate: 13}},
+				ThrottleWriteBpsDevice:  OciDeviceRates{{Major: 21, Minor: 22, Rate: 23}},
+				ThrottleReadIOPSDevice:  OciDeviceRates{{Major: 31, Minor: 32, Rate: 33}},
+				ThrottleWriteIOPSDevice: OciDeviceRates{{Major: 41, Minor: 42, Rate: 43}},
+			},
+			expectedErrorCount: 6,
+			expectedErrorSubstrings: []string{
+				"file not found",
+				"blkio.bfq.weight",
+				"blkio.bfq.weight_device",
+				"blkio.throttle.read_bps_device",
+				"blkio.throttle.write_bps_device",
+				"blkio.throttle.read_iops_device",
+				"blkio.throttle.write_iops_device",
+			},
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsi = tc.fsi
+			overrideFsFuncs(fsi.(*fsMock), tc.fsFuncs)
+			err := SetBlkioParameters(tc.cntnrDir, tc.blockIO)
+			testutils.VerifyError(t, err, tc.expectedErrorCount, tc.expectedErrorSubstrings)
+			validateWriteHistory(t, tc.expectedFsWrites, fsi.(*fsMock).files)
+		})
+	}
+}

--- a/pkg/cgroups/cgroupcontrol.go
+++ b/pkg/cgroups/cgroupcontrol.go
@@ -1,0 +1,237 @@
+// Copyright 2020-2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+)
+
+// Controller is our enumerated type for cgroup controllers.
+type Controller int
+
+// Group represents a control group.
+type Group string
+
+//nolint
+const (
+	// UnkownController represents a controller of unknown type.
+	UnknownController Controller = iota
+	// blkio cgroup controller.
+	Blkio
+	// cpu cgroup controller.
+	Cpu
+	// cpuacct cgroup controller.
+	Cpuacct
+	// cpuset cgroup controller.
+	Cpuset
+	// devices cgroup controller.
+	Devices
+	// freezer cgroup controller.
+	Freezer
+	// hugetlb cgroup controller.
+	Hugetlb
+	// memory cgroup controller.
+	Memory
+	// net_cls cgroup controller.
+	NetCls
+	// net_prio cgroup controller.
+	NetPrio
+	// per_event cgroup controller.
+	PerfEvent
+	// pids cgroup controller.
+	Pids
+)
+
+var (
+	// controllerNames maps controllers to names/relative paths.
+	controllerNames = map[Controller]string{
+		Blkio:     "blkio",
+		Cpu:       "cpu",
+		Cpuacct:   "cpuacct",
+		Cpuset:    "cpuset",
+		Devices:   "devices",
+		Freezer:   "freezer",
+		Hugetlb:   "hugetlb",
+		Memory:    "memory",
+		NetCls:    "net_cls",
+		NetPrio:   "net_prio",
+		PerfEvent: "perf_event",
+		Pids:      "pids",
+	}
+
+	// controllerNames maps controllers to names/relative paths.
+	controllerDirs = map[string]Controller{
+		"blkio":      Blkio,
+		"cpu":        Cpu,
+		"cpuacct":    Cpuacct,
+		"cpuset":     Cpuset,
+		"devices":    Devices,
+		"freezer":    Freezer,
+		"hugetlb":    Hugetlb,
+		"memory":     Memory,
+		"net_cls":    NetCls,
+		"net_prio":   NetPrio,
+		"perf_event": PerfEvent,
+		"pids":       Pids,
+	}
+)
+
+// String returns the name of the given controller.
+func (c Controller) String() string {
+	if name, ok := controllerNames[c]; ok {
+		return name
+	}
+	return "unknown"
+}
+
+// Path returns the absolute path of the given controller.
+func (c Controller) Path() string {
+	return path.Join(mountDir, c.String())
+}
+
+// RelPath returns the relative path of the given controller.
+func (c Controller) RelPath() string {
+	return c.String()
+}
+
+// Group returns the given group for the controller.
+func (c Controller) Group(group string) Group {
+	return Group(path.Join(mountDir, c.String(), group))
+}
+
+// AsGroup returns the group for the given absolute directory path.
+func AsGroup(absDir string) Group {
+	return Group(absDir)
+}
+
+// Controller returns the controller for the group.
+func (g Group) Controller() Controller {
+	relPath := strings.TrimPrefix(string(g), mountDir+"/")
+	split := strings.SplitN(relPath, "/", 2)
+	if len(split) > 0 {
+		return controllerDirs[split[0]]
+	}
+	return UnknownController
+}
+
+// GetTasks reads the pids of threads currently assigned to the group.
+func (g Group) GetTasks() ([]string, error) {
+	return g.readPids(Tasks)
+}
+
+// GetProcesses reads the pids of processes currently assigned to the group.
+func (g Group) GetProcesses() ([]string, error) {
+	return g.readPids(Procs)
+}
+
+// AddTasks writes the given thread pids to the group.
+func (g Group) AddTasks(pids ...string) error {
+	return g.writePids(Tasks, pids...)
+}
+
+// AddProcesses writes the given process pids to the group.
+func (g Group) AddProcesses(pids ...string) error {
+	return g.writePids(Procs, pids...)
+}
+
+// Write writes the formatted data to the groups entry.
+func (g Group) Write(entry, format string, args ...interface{}) error {
+	entryPath := path.Join(string(g), entry)
+	f, err := fsi.OpenFile(entryPath, os.O_WRONLY, 0644)
+	if err != nil {
+		return g.errorf("%q: failed to open for writing: %v", entry, err)
+	}
+	defer f.Close()
+
+	data := fmt.Sprintf(format, args...)
+	if _, err := f.Write([]byte(data)); err != nil {
+		return g.errorf("%q: failed to write %q: %v", entry, data, err)
+	}
+
+	return nil
+}
+
+// Read the groups entry and return contents in a string
+func (g Group) Read(entry string) (string, error) {
+	var buf bytes.Buffer
+	entryPath := path.Join(string(g), entry)
+	f, err := fsi.OpenFile(entryPath, os.O_RDONLY, 0644)
+	if err != nil {
+		return "", g.errorf("%q: failed to open for reading: %v", entry, err)
+	}
+	defer f.Close()
+	if _, err := buf.ReadFrom(f); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// readPids reads pids from a cgroup's tasks or procs entry.
+func (g Group) readPids(entry string) ([]string, error) {
+	var pids []string
+
+	pidFile := path.Join(string(g), entry)
+
+	f, err := fsi.OpenFile(pidFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, g.errorf("failed to open %q: %v", entry, err)
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		pids = append(pids, s.Text())
+	}
+	if s.Err() != nil {
+		return nil, g.errorf("failed to read %q: %v", entry, err)
+	}
+
+	return pids, nil
+}
+
+// writePids writes pids to a cgroup's tasks or procs entry.
+func (g Group) writePids(entry string, pids ...string) error {
+	pidFile := path.Join(string(g), entry)
+
+	f, err := fsi.OpenFile(pidFile, os.O_WRONLY, 0644)
+	if err != nil {
+		return g.errorf("failed to write pids to %q: %v", pidFile, err)
+	}
+	defer f.Close()
+
+	for _, pid := range pids {
+		if _, err := f.Write([]byte(pid)); err != nil {
+			if !errors.Is(err, syscall.ESRCH) {
+				return g.errorf("failed to write pid %s to %q: %v",
+					pidFile, pid, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// error returns a formatted group-specific error.
+func (g Group) errorf(format string, args ...interface{}) error {
+	name := strings.TrimPrefix(string(g), mountDir+"/")
+	return fmt.Errorf("cgroup "+name+": "+format, args...)
+}

--- a/pkg/cgroups/cgroupcontrol_test.go
+++ b/pkg/cgroups/cgroupcontrol_test.go
@@ -1,0 +1,104 @@
+package cgroups
+
+import (
+	"io"
+	"syscall"
+	"testing"
+
+	"github.com/intel/goresctrl/pkg/testutils"
+)
+
+var cpuacctMyGroupTasks string = ""
+var testfiles fsiIface = NewFsiMock(map[string]mockFile{
+	"/sys/fs/cgroup/blkio/kubepods/tasks": {
+		data: []byte("1\n23\n4567890\n"),
+	},
+	"/sys/fs/cgroup/cpu/open/permission/denied/cgroup.procs": {
+		// simulate open permission denied
+		open: func(string) (fileIface, error) {
+			return nil, syscall.EACCES
+		},
+	},
+	"/sys/fs/cgroup/cpuacct/store/all/writes/tasks": {
+		// everything that is written can be read
+		// (no overwrite / truncate)
+		write: func(b []byte) (int, error) {
+			cpuacctMyGroupTasks = cpuacctMyGroupTasks + string(b) + "\n"
+			return len(b), nil
+		},
+		read: func(b []byte) (int, error) {
+			if len(cpuacctMyGroupTasks) == 0 {
+				return 0, io.EOF
+			}
+			bytes := len(cpuacctMyGroupTasks)
+			copy(b, []byte(cpuacctMyGroupTasks))
+			cpuacctMyGroupTasks = ""
+			return bytes, nil
+		},
+	},
+	"/sys/fs/cgroup/cpuset/read/io/error/tasks": {
+		// every read causes I/O error
+		read: func(b []byte) (int, error) {
+			return 0, syscall.EIO
+		},
+	},
+	"/sys/fs/cgroup/devices/write/io/error/cgroup.procs": {
+		// every write causes I/O error
+		write: func(b []byte) (int, error) {
+			return 0, syscall.EIO
+		},
+	},
+})
+
+func TestGetTasks(t *testing.T) {
+	fsi = testfiles
+	tasks, err := Blkio.Group("kubepods").GetTasks()
+	testutils.VerifyNoError(t, err)
+	testutils.VerifyStringSlices(t, []string{"1", "23", "4567890"}, tasks)
+}
+
+func TestGetProcesses(t *testing.T) {
+	fsi = testfiles
+	_, err := Cpu.Group("open/permission/denied").GetProcesses()
+	testutils.VerifyError(t, err, 1, []string{"permission denied"})
+}
+
+func TestAddTasks(t *testing.T) {
+	fsi = testfiles
+	if err := Cpuacct.Group("store/all/writes").AddTasks("0", "987654321"); !testutils.VerifyNoError(t, err) {
+		return
+	}
+	if err := Cpuacct.Group("store/all/writes").AddTasks(); !testutils.VerifyNoError(t, err) {
+		return
+	}
+	if err := Cpuacct.Group("store/all/writes").AddTasks("12"); !testutils.VerifyNoError(t, err) {
+		return
+	}
+	tasks, err := Cpuacct.Group("store/all/writes").GetTasks()
+	testutils.VerifyNoError(t, err)
+	testutils.VerifyStringSlices(t, []string{"0", "987654321", "12"}, tasks)
+}
+
+func TestAddProcesses(t *testing.T) {
+	fsi = testfiles
+	err := Devices.Group("write/io/error").AddProcesses("1")
+	testutils.VerifyError(t, err, 1, []string{"input/output error"})
+	err = Freezer.Group("file/not/found").AddProcesses("1")
+	testutils.VerifyError(t, err, 1, []string{"file not found"})
+}
+
+func TestAsGroup(t *testing.T) {
+	memGroupIn := Memory.Group("my/memory")
+	memGroupOut := AsGroup(string(memGroupIn))
+	testutils.VerifyStrings(t, string(memGroupIn), string(memGroupOut))
+}
+
+func TestGroupToController(t *testing.T) {
+	c := Hugetlb.Group("my/group").Controller()
+	testutils.VerifyStrings(t, "hugetlb", c.String())
+}
+
+func TestRelPath(t *testing.T) {
+	relPath := NetCls.RelPath()
+	testutils.VerifyStrings(t, "net_cls", relPath)
+}

--- a/pkg/cgroups/cgroupid.go
+++ b/pkg/cgroups/cgroupid.go
@@ -1,0 +1,77 @@
+package cgroups
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// CgroupID implements mapping kernel cgroup IDs to cgroupfs paths with transparent caching.
+type CgroupID struct {
+	root  string
+	cache map[uint64]string
+	sync.Mutex
+}
+
+// NewCgroupID creates a new CgroupID map/cache.
+func NewCgroupID(root string) *CgroupID {
+	return &CgroupID{
+		root:  root,
+		cache: make(map[uint64]string),
+	}
+}
+
+func getID(path string) uint64 {
+	h, _, err := unix.NameToHandleAt(unix.AT_FDCWD, path, 0)
+	if err != nil {
+		return 0
+	}
+
+	return binary.LittleEndian.Uint64(h.Bytes())
+}
+
+// Find finds the path for the given cgroup id.
+func (cgid *CgroupID) Find(id uint64) (string, error) {
+	found := false
+	var p string
+
+	cgid.Lock()
+	defer cgid.Unlock()
+
+	if path, ok := cgid.cache[id]; ok {
+		return path, nil
+	}
+
+	err := fsi.Walk(cgid.root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
+		if found {
+			return filepath.SkipDir
+		}
+
+		if info.IsDir() && id == getID(path) {
+			found = true
+			p = path
+			return filepath.SkipDir
+		}
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	} else if !found {
+		return "", fmt.Errorf("cgroupid %v not found", id)
+	} else {
+		cgid.cache[id] = p
+		return p, nil
+	}
+}

--- a/pkg/cgroups/cgrouppath.go
+++ b/pkg/cgroups/cgrouppath.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroups
+
+import (
+	"path"
+	"path/filepath"
+)
+
+//nolint
+const (
+	// Tasks is a cgroup's "tasks" entry.
+	Tasks = "tasks"
+	// Procs is cgroup's "cgroup.procs" entry.
+	Procs = "cgroup.procs"
+	// CpuShares is the cpu controller's "cpu.shares" entry.
+	CpuShares = "cpu.shares"
+	// CpuPeriod is the cpu controller's "cpu.cfs_period_us" entry.
+	CpuPeriod = "cpu.cfs_period_us"
+	// CpuQuota is the cpu controller's "cpu.cfs_quota_us" entry.
+	CpuQuota = "cpu.cfs_quota_us"
+	// CpusetCpus is the cpuset controller's cpuset.cpus entry.
+	CpusetCpus = "cpuset.cpus"
+	// CpusetMems is the cpuset controller's cpuset.mems entry.
+	CpusetMems = "cpuset.mems"
+)
+
+var (
+	// mount is the parent directory for per-controller cgroupfs mounts.
+	mountDir = "/sys/fs/cgroup"
+	// v2Dir is the parent directory for per-controller cgroupfs mounts.
+	v2Dir = path.Join(mountDir, "unified")
+	// KubeletRoot is the --cgroup-root option the kubelet is running with.
+	KubeletRoot = ""
+)
+
+// GetMountDir returns the common mount point for cgroup v1 controllers.
+func GetMountDir() string {
+	return mountDir
+}
+
+// SetMountDir sets the common mount point for the cgroup v1 controllers.
+func SetMountDir(dir string) {
+	v2, _ := filepath.Rel(mountDir, v2Dir)
+	mountDir = dir
+	if v2 != "" {
+		v2Dir = path.Join(mountDir, v2)
+	}
+}
+
+// GetV2Dir returns the cgroup v2 unified mount directory.
+func GetV2Dir() string {
+	return v2Dir
+}
+
+// SetV2Dir sets the unified cgroup v2 mount directory.
+func SetV2Dir(dir string) {
+	if dir[0] == '/' {
+		v2Dir = dir
+	} else {
+		v2Dir = path.Join(mountDir, v2Dir)
+	}
+}

--- a/pkg/cgroups/fsi.go
+++ b/pkg/cgroups/fsi.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This module defines filesystem interface (fsi) through which
+// cgroups package accesses files.
+
+package cgroups
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type fsiIface interface {
+	Open(name string) (fileIface, error)
+	OpenFile(name string, flag int, perm os.FileMode) (fileIface, error)
+	Walk(string, filepath.WalkFunc) error
+	Lstat(path string) (os.FileInfo, error)
+}
+
+type fileIface interface {
+	Close() error
+	Read(p []byte) (n int, err error)
+	Write(b []byte) (n int, err error)
+}
+
+// Set the default filesystem interface
+var fsi fsiIface = newFsiOS()

--- a/pkg/cgroups/fsimock.go
+++ b/pkg/cgroups/fsimock.go
@@ -1,0 +1,230 @@
+// Copyright 2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This module implements a mock filesystem that can be used as a
+// replacement for the native filesystem interface (fsi).
+
+package cgroups
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type fsMock struct {
+	files map[string]*mockFile // filesystem contents
+}
+
+type mockFile struct {
+	// User-defined file properties
+	data []byte // contents of the file
+
+	// User/fsimock-defined properties
+	info *mockFileInfo
+
+	// File-specific user-overrides for the default file behavior
+	open  func(string) (fileIface, error)
+	read  func([]byte) (int, error)
+	write func([]byte) (int, error)
+
+	// fsimock-defined properties
+	fs           *fsMock
+	filename     string
+	handle       *mockFileHandle
+	writeHistory [][]byte
+}
+
+type mockFileHandle struct {
+	pos int
+}
+
+type mockFileInfo struct {
+	mode os.FileMode
+	name string
+	mf   *mockFile
+}
+
+func NewFsiMock(files map[string]mockFile) fsiIface {
+	mfs := fsMock{}
+	mfs.files = map[string]*mockFile{}
+	for filename, usermf := range files {
+		mf := usermf
+		if mf.info == nil {
+			mf.info = &mockFileInfo{}
+		}
+		if mf.info.name == "" {
+			mf.info.name = filepath.Base(filename)
+		}
+		mf.filename = filename
+		mf.info.mf = &mf
+		mf.fs = &mfs
+		mfs.files[filename] = &mf
+	}
+	return &mfs
+}
+
+func (mfs fsMock) OpenFile(name string, flag int, perm os.FileMode) (fileIface, error) {
+	fsmockLog("OpenFile(%q, %d, %d)", name, flag, perm)
+	if mf, ok := mfs.files[name]; ok {
+		mf.handle = &mockFileHandle{}
+		if mf.open != nil {
+			return mf.open(name)
+		}
+		return *mf, nil
+	}
+	return nil, fsmockErrorf("%q: file not found", name)
+}
+
+func (mfs fsMock) Open(name string) (fileIface, error) {
+	return mfs.OpenFile(name, 0, 0)
+}
+
+func (mfs fsMock) Walk(path string, walkFn filepath.WalkFunc) error {
+	dirPath := strings.TrimSuffix(path, "/")
+	info, err := mfs.Lstat(dirPath)
+	if err != nil {
+		err = walkFn(path, nil, err)
+		return err
+	}
+	if !info.IsDir() {
+		return walkFn(path, info, nil)
+	}
+	err = walkFn(path, info, nil)
+	if err != nil {
+		return err
+	}
+	for _, name := range mfs.dirContents(dirPath) {
+		if err = mfs.Walk(dirPath+"/"+name, walkFn); err != nil && err != filepath.SkipDir {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mfs fsMock) dirContents(path string) []string {
+	dirPathS := strings.TrimSuffix(path, "/") + "/"
+	contentSet := map[string]struct{}{}
+	for filename := range mfs.files {
+		if !strings.HasPrefix(filename, dirPathS) {
+			continue
+		}
+		relToDirPath := strings.TrimPrefix(filename, dirPathS)
+		names := strings.SplitN(relToDirPath, "/", 2)
+		contentSet[names[0]] = struct{}{}
+	}
+	contents := make([]string, 0, len(contentSet))
+	for name := range contentSet {
+		contents = append(contents, name)
+	}
+	return contents
+}
+
+func (mfs fsMock) Lstat(path string) (os.FileInfo, error) {
+	if mf, ok := mfs.files[path]; ok {
+		return *mf.info, nil
+	}
+	if len(mfs.dirContents(path)) > 0 {
+		return mockFileInfo{
+			name: filepath.Base(path),
+			mode: os.ModeDir,
+		}, nil
+	}
+	return mockFileInfo{}, fsmockErrorf("%q: file not found", path)
+}
+
+func (mfi mockFileInfo) Name() string {
+	return mfi.name
+}
+func (mfi mockFileInfo) Size() int64 {
+	if mfi.mf != nil {
+		return int64(len(mfi.mf.data))
+	}
+	return 0
+}
+func (mfi mockFileInfo) Mode() os.FileMode {
+	return mfi.mode
+}
+
+func (mfi mockFileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (mfi mockFileInfo) IsDir() bool {
+	return mfi.mode&os.ModeDir != 0
+}
+
+func (mfi mockFileInfo) Sys() interface{} {
+	return nil
+}
+
+func (mf mockFile) Write(b []byte) (n int, err error) {
+	pos := mf.handle.pos
+	if mf.write != nil {
+		n, err = mf.write(b)
+		if err == nil {
+			mf.fs.files[mf.filename].writeHistory = append(mf.fs.files[mf.filename].writeHistory, b)
+		}
+	} else {
+		newpos := pos + len(b)
+		if newpos > cap(mf.data) {
+			newdata := make([]byte, newpos)
+			copy(newdata, mf.data)
+			mf.data = newdata
+		}
+		copy(mf.data[pos:newpos], b)
+		mf.handle.pos = newpos
+		if f, ok := mf.fs.files[mf.filename]; ok {
+			f.data = mf.data
+		}
+		mf.fs.files[mf.filename].writeHistory = append(mf.fs.files[mf.filename].writeHistory, b)
+	}
+	fsmockLog("{%q, pos=%d}.Write([%d]byte(%q)) = (%d, %v) %q", mf.filename, pos, len(b), string(b), n, err, mf.fs.files[mf.filename].data)
+	return n, err
+}
+
+func (mf mockFile) Read(b []byte) (n int, err error) {
+	pos := mf.handle.pos
+	if mf.read != nil {
+		n, err = mf.read(b)
+	} else {
+		n = len(mf.data) - pos
+		err = nil
+		if n <= 0 {
+			err = io.EOF
+		}
+		if n > cap(b) {
+			n = cap(b)
+		}
+		copy(b, mf.data[pos:pos+n])
+		mf.handle.pos += n
+	}
+	fsmockLog("{%q, pos=%d}.Read([%d]byte) = (%d, %v)\n", mf.filename, pos, len(b), n, err)
+	return
+}
+
+func (mf mockFile) Close() error {
+	return nil
+}
+
+func fsmockLog(format string, args ...interface{}) {
+	fmt.Printf("fsmock: "+format+"\n", args...)
+}
+
+func fsmockErrorf(format string, args ...interface{}) error {
+	return fmt.Errorf("fsmock: "+format, args...)
+}

--- a/pkg/cgroups/fsimock_test.go
+++ b/pkg/cgroups/fsimock_test.go
@@ -1,0 +1,65 @@
+package cgroups
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/intel/goresctrl/pkg/testutils"
+)
+
+var fsMockUtFiles map[string]mockFile = map[string]mockFile{
+	"/my/emptyfile": {},
+	"/my/emptydir": {
+		info: &mockFileInfo{mode: os.ModeDir},
+	},
+	"/my/dir/data0": {data: []byte("abc")},
+	"/my/dir/data1": {data: []byte("xyz")},
+}
+
+func TestWalk(t *testing.T) {
+	fs := NewFsiMock(fsMockUtFiles)
+	foundNotInMyDir := []string{}
+	err := fs.Walk("/", func(path string, info os.FileInfo, err error) error {
+		if filepath.Base(path) == "dir" {
+			return filepath.SkipDir
+		}
+		foundNotInMyDir = append(foundNotInMyDir, path)
+		return nil
+	})
+	testutils.VerifyNoError(t, err)
+	sort.Strings(foundNotInMyDir)
+	testutils.VerifyStringSlices(t, []string{"/", "/my", "/my/emptydir", "/my/emptyfile"}, foundNotInMyDir)
+}
+
+func TestReadWrite(t *testing.T) {
+	var info os.FileInfo
+	fs := NewFsiMock(fsMockUtFiles)
+	f, err := fs.OpenFile("/my/dir/data0", os.O_WRONLY, 0)
+	testutils.VerifyNoError(t, err)
+	_, err = f.Write([]byte{})
+	testutils.VerifyNoError(t, err)
+	_, err = f.Write([]byte("01"))
+	testutils.VerifyNoError(t, err)
+	info, err = fs.Lstat("/my/dir/data0")
+	testutils.VerifyNoError(t, err)
+	if info.Size() != 3 {
+		t.Errorf("expected file size %d, got %d", 3, info.Size())
+	}
+	_, err = f.Write([]byte("23"))
+	testutils.VerifyNoError(t, err)
+	if info.Size() != 4 {
+		t.Errorf("expected file size %d, got %d", 4, info.Size())
+	}
+	f.Close()
+	f, err = fs.OpenFile("/my/dir/data0", os.O_RDONLY, 0)
+	testutils.VerifyNoError(t, err)
+	buf := make([]byte, 10)
+	bytes, err := f.Read(buf)
+	testutils.VerifyNoError(t, err)
+	if bytes != 4 {
+		t.Errorf("expected to read %d bytes, Read returned %d", 4, bytes)
+	}
+	testutils.VerifyStringSlices(t, []string{"0123"}, []string{string(buf[:bytes])})
+}

--- a/pkg/cgroups/fsios.go
+++ b/pkg/cgroups/fsios.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This module provides the native implementation of the filesystem
+// interface (fsi).
+
+package cgroups
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type fsOs struct{}
+
+type osFile struct {
+	file *os.File
+}
+
+func newFsiOS() fsiIface {
+	return fsOs{}
+}
+
+func (fsOs) OpenFile(name string, flag int, perm os.FileMode) (fileIface, error) {
+	f, err := os.OpenFile(name, flag, perm)
+	return osFile{f}, err
+}
+
+func (fsOs) Open(name string) (fileIface, error) {
+	f, err := os.Open(name)
+	return osFile{f}, err
+}
+
+func (fsOs) Lstat(name string) (os.FileInfo, error) {
+	return os.Lstat(name)
+}
+
+func (fsOs) Walk(root string, walkFn filepath.WalkFunc) error {
+	return filepath.Walk(root, walkFn)
+}
+
+func (osf osFile) Write(b []byte) (n int, err error) {
+	return osf.file.Write(b)
+}
+
+func (osf osFile) Read(b []byte) (n int, err error) {
+	return osf.file.Read(b)
+}
+
+func (osf osFile) Close() error {
+	return osf.file.Close()
+}

--- a/pkg/testutils/verify.go
+++ b/pkg/testutils/verify.go
@@ -1,0 +1,96 @@
+// Copyright 2020-2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// VerifyDeepEqual checks that two values (including structures) are equal, or else it fails the test.
+func VerifyDeepEqual(t *testing.T, valueName string, expectedValue interface{}, seenValue interface{}) bool {
+	if reflect.DeepEqual(expectedValue, seenValue) {
+		return true
+	}
+	t.Errorf("expected %s value %+v, got %+v", valueName, expectedValue, seenValue)
+	return false
+}
+
+// VerifyError checks a (multi)error has expected properties, or else it fails the test.
+func VerifyError(t *testing.T, err error, expectedCount int, expectedSubstrings []string) bool {
+	if expectedCount > 0 {
+		if err == nil {
+			t.Errorf("error expected, got nil")
+			return false
+		}
+		merr, ok := err.(*multierror.Error)
+		if !ok {
+			if expectedCount > 1 {
+				t.Errorf("expected %d errors, but got %#v instead of multierror", expectedCount, err)
+				return false
+			}
+			// If exactly one error is expected, then err
+			// is allowed to be any error, not just a
+			// multierror.
+		} else if len(merr.Errors) != expectedCount {
+			t.Errorf("expected %d errors, but got %d: %v", expectedCount, len(merr.Errors), merr)
+			return false
+		}
+	} else if expectedCount == 0 {
+		if err != nil {
+			t.Errorf("expected 0 errors, but got: %v", err)
+			return false
+		}
+	}
+	for _, substring := range expectedSubstrings {
+		if !strings.Contains(err.Error(), substring) {
+			t.Errorf("expected error with substring %#v, got \"%v\"", substring, err)
+		}
+	}
+	return true
+}
+
+func VerifyNoError(t *testing.T, err error) bool {
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+		return false
+	}
+	return true
+}
+
+func VerifyStrings(t *testing.T, expected string, got string) bool {
+	if expected != got {
+		t.Errorf("Strings differ: expected %q, got %q", expected, got)
+		return false
+	}
+	return true
+}
+
+func VerifyStringSlices(t *testing.T, expected []string, got []string) bool {
+	if len(expected) != len(got) {
+		t.Errorf("Expected string slice of length %d, got %d", len(expected), len(got))
+		return false
+	}
+	for i, es := range expected {
+		if es != got[i] {
+			t.Errorf("Slices differ: expected[%d]=%q, got[%d]=%q", i, es, i, got[i])
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
The core of the cgroup filesystem interface is copied from the CRI
Resource Manager pkg/cgroups with a few changes and additions:
- Change cgroupblkio to fully utilize the group-independent cgroup
  interface instead of accessing to files directly.
- Add fsios to wrap all accesses to the underlying filesystem.
- Add fsimock to enable testing wanted filesystem contents and
  simulating arbitrary errors via user-defined open/read/write
  functions.
- Change cgroupblkio unit tests to use fsimock.
- Add unit tests to other modules in the package.
- Add common verifications to testutils package.