### PR TITLE
rdt: specify a well-defined configuration interface

### DIFF
--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Intel Corporation
+Copyright 2019-2021 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ limitations under the License.
 package rdt
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/bits"
@@ -27,20 +28,40 @@ import (
 	"github.com/intel/goresctrl/pkg/utils"
 )
 
-// Config represents the raw RDT configuration data from the configmap
+// Config is the user-specified RDT configuration
 type Config struct {
 	Options    Options `json:"options"`
 	Partitions map[string]struct {
-		L2Allocation interface{} `json:"l2Allocation"`
-		L3Allocation interface{} `json:"l3Allocation"`
-		MBAllocation interface{} `json:"mbAllocation"`
+		L2Allocation CatConfig `json:"l2Allocation"`
+		L3Allocation CatConfig `json:"l3Allocation"`
+		MBAllocation MbaConfig `json:"mbAllocation"`
 		Classes      map[string]struct {
-			L2Schema interface{} `json:"l2Schema"`
-			L3Schema interface{} `json:"l3Schema"`
-			MBSchema interface{} `json:"mbSchema"`
+			L2Allocation CatConfig `json:"l2Allocation"`
+			L3Allocation CatConfig `json:"l3Allocation"`
+			MBAllocation MbaConfig `json:"mbAllocation"`
 		} `json:"classes"`
 	} `json:"partitions"`
 }
+
+// CatConfig contains the L2 or L3 cache allocation configuration for one partition or class
+type CatConfig map[string]CacheIdCatConfig
+
+// MbaConfig contains the memory bandwidth configuration for one partition or class
+type MbaConfig map[string]CacheIdMbaConfig
+
+// CacheIdCatConfig is the cache allocation configuration for one cache id
+type CacheIdCatConfig struct {
+	Unified string
+	Code    string
+	Data    string
+}
+
+// CacheIdMbaConfig is the memory bandwidth configuration for one cache id
+type CacheIdMbaConfig []string
+
+// CacheIdAll is a special cache id used to denote a default, used as a
+// fallback for all cache ids that are not explicitly specified
+const CacheIdAll = "all"
 
 // config represents the final (parsed and resolved) runtime configuration of
 // RDT Control
@@ -500,19 +521,19 @@ func (c *Config) resolveCatPartitions(lvl cacheLevel, conf partitionSet) error {
 	}
 	sort.Strings(names)
 
-	parser := newCatConfigParser(lvl)
 	resolver := newCacheResolver(lvl, names)
 
-	// Parse requested allocations from raw config load the resolver
+	// Parse requested allocations from user config and load the resolver
 	for _, name := range names {
 		var allocations catSchema
 		var err error
 		switch lvl {
 		case L2:
-			allocations, err = parser.parse(c.Partitions[name].L2Allocation)
+			allocations, err = c.Partitions[name].L2Allocation.toSchema(L2)
 		case L3:
-			allocations, err = parser.parse(c.Partitions[name].L3Allocation)
+			allocations, err = c.Partitions[name].L3Allocation.toSchema(L3)
 		}
+
 		if err != nil {
 			return fmt.Errorf("failed to parse %s allocation request for partition %q: %v", lvl, name, err)
 		}
@@ -742,9 +763,9 @@ func (r *cacheResolver) resolveAbsolute(id uint64, typ catSchemaType) error {
 
 // resolveMBPartitions tries to resolve requested MB allocations between partitions
 func (c *Config) resolveMBPartitions(conf partitionSet) error {
-	// We use percentage values directly from the raw conf
+	// We use percentage values directly from the user conf
 	for name, partition := range c.Partitions {
-		allocations, err := parseRawMBAllocations(partition.MBAllocation)
+		allocations, err := partition.MBAllocation.toSchema()
 		if err != nil {
 			return fmt.Errorf("failed to resolve MB allocation for partition %q: %v", name, err)
 		}
@@ -764,8 +785,6 @@ func (c *Config) resolveMBPartitions(conf partitionSet) error {
 func (c *Config) resolveClasses() (classSet, error) {
 	classes := make(classSet)
 
-	catL3Parser := newCatConfigParser(L3)
-	catL2Parser := newCatConfigParser(L2)
 	for bname, partition := range c.Partitions {
 		for gname, class := range partition.Classes {
 			if _, ok := classes[gname]; ok {
@@ -776,7 +795,7 @@ func (c *Config) resolveClasses() (classSet, error) {
 			gc := &classConfig{Partition: bname,
 				CATSchema: make(map[cacheLevel]catSchema)}
 
-			gc.CATSchema[L2], err = catL2Parser.parse(class.L2Schema)
+			gc.CATSchema[L2], err = class.L2Allocation.toSchema(L2)
 			if err != nil {
 				return classes, fmt.Errorf("failed to resolve L2 allocation for class %q: %v", gname, err)
 			}
@@ -784,7 +803,7 @@ func (c *Config) resolveClasses() (classSet, error) {
 				return classes, fmt.Errorf("L2 allocation missing from partition %q but class %q specifies L2 schema", bname, gname)
 			}
 
-			gc.CATSchema[L3], err = catL3Parser.parse(class.L3Schema)
+			gc.CATSchema[L3], err = class.L3Allocation.toSchema(L3)
 			if err != nil {
 				return classes, fmt.Errorf("failed to resolve L3 allocation for class %q: %v", gname, err)
 			}
@@ -792,7 +811,7 @@ func (c *Config) resolveClasses() (classSet, error) {
 				return classes, fmt.Errorf("L3 allocation missing from partition %q but class %q specifies L3 schema", bname, gname)
 			}
 
-			gc.MBSchema, err = parseRawMBAllocations(class.MBSchema)
+			gc.MBSchema, err = class.MBAllocation.toSchema()
 			if err != nil {
 				return classes, fmt.Errorf("failed to resolve MB allocation for class %q: %v", gname, err)
 			}
@@ -807,69 +826,123 @@ func (c *Config) resolveClasses() (classSet, error) {
 	return classes, nil
 }
 
-// parseRawMBAllocations parses a raw MB allocation
-func parseRawMBAllocations(raw interface{}) (mbSchema, error) {
-	rawValues, err := preparseRawAllocations(raw, []interface{}{}, info.mb.cacheIds)
-	if err != nil || rawValues == nil {
-		return nil, err
+// toSchema converts a cache allocation config to effective allocation schema covering all cache IDs
+func (c CatConfig) toSchema(lvl cacheLevel) (catSchema, error) {
+	if c == nil {
+		return catSchema{Lvl: lvl}, nil
 	}
 
-	allocations := make(mbSchema, len(rawValues))
-	for id, rawVal := range rawValues {
-		strList, ok := rawVal.([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("not a list value %q", rawVal)
+	allocations := newCatSchema(lvl)
+	minBits := info.cat[lvl].minCbmBits()
+
+	d, ok := c[CacheIdAll]
+	if !ok {
+		d = CacheIdCatConfig{Unified: "100%"}
+	}
+	defaultVal, err := d.parse(minBits)
+	if err != nil {
+		return allocations, err
+	}
+
+	// Pre-fill with defaults
+	for _, i := range info.cat[lvl].cacheIds {
+		allocations.Alloc[i] = defaultVal
+	}
+
+	for key, val := range c {
+		if key == CacheIdAll {
+			continue
 		}
-		allocations[id], err = parseMBAllocation(strList)
+
+		ids, err := listStrToArray(key)
 		if err != nil {
-			return nil, err
+			return allocations, err
+		}
+
+		schemaVal, err := val.parse(minBits)
+		if err != nil {
+			return allocations, err
+		}
+
+		for _, id := range ids {
+			if _, ok := allocations.Alloc[uint64(id)]; ok {
+				allocations.Alloc[uint64(id)] = schemaVal
+			}
 		}
 	}
 
 	return allocations, nil
 }
 
-// preparseRawAllocations "pre-parses" the rawAllocations per each cache id. I.e. it assigns
-// a raw (string) allocation for each cache id
-func preparseRawAllocations(raw interface{}, defaultVal interface{}, cacheIds []uint64) (map[uint64]interface{}, error) {
-	if raw == nil {
+// catConfig is a helper for unmarshalling CatConfig
+type catConfig CatConfig
+
+// UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
+func (c *CatConfig) UnmarshalJSON(data []byte) error {
+	raw := new(interface{})
+
+	err := json.Unmarshal(data, raw)
+	if err != nil {
+		return err
+	}
+
+	conf := CatConfig{}
+	switch v := (*raw).(type) {
+	case string:
+		conf[CacheIdAll] = CacheIdCatConfig{Unified: v}
+	default:
+		// Use the helper type to avoid infinite recursion
+		helper := catConfig{}
+		if err := json.Unmarshal(data, &helper); err != nil {
+			return err
+		}
+		for k, v := range helper {
+			conf[k] = v
+		}
+	}
+	*c = conf
+	return nil
+}
+
+// toSchema converts an MB allocation config to effective allocation schema covering all cache IDs
+func (c MbaConfig) toSchema() (mbSchema, error) {
+	if c == nil {
 		return nil, nil
 	}
 
-	var rawPerCacheId map[string]interface{}
-	allocations := make(map[uint64]interface{}, len(cacheIds))
-
-	switch value := raw.(type) {
-	case string:
-		defaultVal = value
-	case []interface{}:
-		defaultVal = value
-	case map[string]interface{}:
-		if all, ok := value["all"]; ok {
-			defaultVal = all
-		} else if defaultVal == nil {
-			return nil, fmt.Errorf("'all' is missing")
-		}
-		rawPerCacheId = value
-	default:
-		return allocations, fmt.Errorf("invalid structure of allocation schema '%v' (%T)", raw, raw)
+	d, ok := c[CacheIdAll]
+	if !ok {
+		d = CacheIdMbaConfig{"100" + mbSuffixPct, "4294967295" + mbSuffixMbps}
+	}
+	defaultVal, err := d.parse()
+	if err != nil {
+		return nil, err
 	}
 
-	for _, i := range cacheIds {
+	allocations := make(mbSchema, len(info.mb.cacheIds))
+	// Pre-fill with defaults
+	for _, i := range info.mb.cacheIds {
 		allocations[i] = defaultVal
 	}
 
-	for key, val := range rawPerCacheId {
-		if key == "all" {
+	for key, val := range c {
+		if key == CacheIdAll {
 			continue
 		}
+
 		ids, err := listStrToArray(key)
 		if err != nil {
 			return nil, err
 		}
+
+		schemaVal, err := val.parse()
+		if err != nil {
+			return nil, err
+		}
+
 		for _, id := range ids {
 			if _, ok := allocations[uint64(id)]; ok {
-				allocations[uint64(id)] = val
+				allocations[uint64(id)] = schemaVal
 			}
 		}
 	}
@@ -877,87 +950,141 @@ func preparseRawAllocations(raw interface{}, defaultVal interface{}, cacheIds []
 	return allocations, nil
 }
 
-// catConfigParser is a helper for parsing cache allocation from the input config
-type catConfigParser struct {
-	lvl     cacheLevel
-	ids     []uint64
-	minBits uint64
-}
+// mbaConfig is a helper for unmarshalling MbaConfig
+type mbaConfig MbaConfig
 
-func newCatConfigParser(lvl cacheLevel) *catConfigParser {
-	return &catConfigParser{
-		lvl:     lvl,
-		ids:     info.cat[lvl].cacheIds,
-		minBits: info.cat[lvl].minCbmBits()}
-}
+// UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
+func (c *MbaConfig) UnmarshalJSON(data []byte) error {
+	raw := new(interface{})
 
-// parse parses an L3 cache allocation from the input config
-func (p *catConfigParser) parse(raw interface{}) (catSchema, error) {
-	rawValues, err := preparseRawAllocations(raw, "100%", p.ids)
-	if err != nil || rawValues == nil {
-		return catSchema{Lvl: p.lvl}, err
+	err := json.Unmarshal(data, raw)
+	if err != nil {
+		return err
 	}
 
-	allocations := newCatSchema(p.lvl)
-	for id, rawVal := range rawValues {
-		allocations.Alloc[id], err = p.parseSchema(rawVal)
-		if err != nil {
-			return allocations, err
+	conf := MbaConfig{}
+	switch (*raw).(type) {
+	case []interface{}:
+		helper := CacheIdMbaConfig{}
+		if err := json.Unmarshal(data, &helper); err != nil {
+			return err
+		}
+		conf[CacheIdAll] = helper
+	default:
+		// Use the helper type to avoid infinite recursion
+		helper := mbaConfig{}
+		if err := json.Unmarshal(data, &helper); err != nil {
+			return err
+		}
+		for k, v := range helper {
+			conf[k] = v
 		}
 	}
-
-	return allocations, nil
+	*c = conf
+	return nil
 }
 
-// parseSchema parses a generic string or map of strings into l3Allocation struct
-func (p *catConfigParser) parseSchema(raw interface{}) (catAllocation, error) {
+// parse per cache-id CAT configuration into an effective allocation to be used
+// in the CAT schema
+func (c *CacheIdCatConfig) parse(minBits uint64) (catAllocation, error) {
 	var err error
 	allocation := catAllocation{}
 
-	switch value := raw.(type) {
-	case string:
-		allocation.Unified, err = p.parseString(value)
-		if err != nil {
-			return allocation, err
-		}
-	case map[string]interface{}:
-		for k, v := range value {
-			s, ok := v.(string)
-			if !ok {
-				return allocation, fmt.Errorf("not a string value %q", v)
-			}
-			switch strings.ToLower(k) {
-			case string(catSchemaTypeUnified):
-				allocation.Unified, err = p.parseString(s)
-			case string(catSchemaTypeCode):
-				allocation.Code, err = p.parseString(s)
-			case string(catSchemaTypeData):
-				allocation.Data, err = p.parseString(s)
-			}
-			if err != nil {
-				return allocation, err
-			}
-		}
-	default:
-		return allocation, fmt.Errorf("invalid structure of cache schema %q", raw)
+	allocation.Unified, err = parseCacheAllocationString(minBits, c.Unified)
+	if err != nil {
+		return allocation, err
+	}
+	allocation.Code, err = parseCacheAllocationString(minBits, c.Code)
+	if err != nil {
+		return allocation, err
+	}
+	allocation.Data, err = parseCacheAllocationString(minBits, c.Data)
+	if err != nil {
+		return allocation, err
 	}
 
 	// Sanity check for the configuration
 	if allocation.Unified == nil {
-		return allocation, fmt.Errorf("'unified' not specified in cache schema %s", raw)
+		return allocation, fmt.Errorf("'unified' not specified in cache schema %s", *c)
 	}
 	if allocation.Code != nil && allocation.Data == nil {
-		return allocation, fmt.Errorf("'code' specified but missing 'data' from cache schema %s", raw)
+		return allocation, fmt.Errorf("'code' specified but missing 'data' from cache schema %s", *c)
 	}
 	if allocation.Code == nil && allocation.Data != nil {
-		return allocation, fmt.Errorf("'data' specified but missing 'code' from cache schema %s", raw)
+		return allocation, fmt.Errorf("'data' specified but missing 'code' from cache schema %s", *c)
 	}
 
 	return allocation, nil
 }
 
-// parseString parses a string value into cacheAllocation type
-func (p *catConfigParser) parseString(data string) (cacheAllocation, error) {
+// cacheIdCatConfig is a helper for unmarshalling CacheIdCatConfig
+type cacheIdCatConfig CacheIdCatConfig
+
+// UnmarshalJSON implements the Unmarshaler interface of "encoding/json"
+func (c *CacheIdCatConfig) UnmarshalJSON(data []byte) error {
+	raw := new(interface{})
+
+	err := json.Unmarshal(data, raw)
+	if err != nil {
+		return err
+	}
+
+	conf := CacheIdCatConfig{}
+	switch v := (*raw).(type) {
+	case string:
+		conf.Unified = v
+	default:
+		// Use the helper type to avoid infinite recursion
+		helper := cacheIdCatConfig{}
+		if err := json.Unmarshal(data, &helper); err != nil {
+			return err
+		}
+		conf.Unified = helper.Unified
+		conf.Code = helper.Code
+		conf.Data = helper.Data
+	}
+	*c = conf
+	return nil
+}
+
+// parse converts a per cache-id MBA configuration into effective value
+// to be used in the MBA schema
+func (c *CacheIdMbaConfig) parse() (uint64, error) {
+	for _, v := range *c {
+		if strings.HasSuffix(v, mbSuffixPct) {
+			if !info.mb.mbpsEnabled {
+				value, err := strconv.ParseUint(strings.TrimSuffix(v, mbSuffixPct), 10, 7)
+				if err != nil {
+					return 0, err
+				}
+				return value, nil
+			}
+		} else if strings.HasSuffix(v, mbSuffixMbps) {
+			if info.mb.mbpsEnabled {
+				value, err := strconv.ParseUint(strings.TrimSuffix(v, mbSuffixMbps), 10, 32)
+				if err != nil {
+					return 0, err
+				}
+				return value, nil
+			}
+		} else {
+			log.Warn("unrecognized MBA allocation unit in %q", v)
+		}
+	}
+
+	// No value for the active mode was specified
+	if info.mb.mbpsEnabled {
+		return 0, fmt.Errorf("missing 'MBps' value from mbSchema; required because 'mba_MBps' is enabled in the system")
+	}
+	return 0, fmt.Errorf("missing '%%' value from mbSchema; required because percentage-based MBA allocation is enabled in the system")
+}
+
+// parseCacheAllocationString converts a string value into cacheAllocation type
+func parseCacheAllocationString(minBits uint64, data string) (cacheAllocation, error) {
+	if data == "" {
+		return nil, nil
+	}
+
 	if data[len(data)-1] == '%' {
 		// Percentages of the max number of bits
 		split := strings.SplitN(data[0:len(data)-1], "-", 2)
@@ -1014,45 +1141,9 @@ func (p *catConfigParser) parseString(data string) (cacheAllocation, error) {
 	if numOnes != 64-bits.LeadingZeros64(value)-bits.TrailingZeros64(value) {
 		return nil, fmt.Errorf("invalid cache bitmask %q: more than one continuous block of ones", data)
 	}
-	if uint64(numOnes) < p.minBits {
-		return nil, fmt.Errorf("invalid %s cache bitmask %q: number of bits less than %d", p.lvl, data, p.minBits)
+	if uint64(numOnes) < minBits {
+		return nil, fmt.Errorf("invalid cache bitmask %q: number of bits less than %d", data, minBits)
 	}
 
 	return catAbsoluteAllocation(value), nil
-}
-
-// parseMBAllocation parses a generic string map into MB allocation value
-func parseMBAllocation(raw []interface{}) (uint64, error) {
-	for _, v := range raw {
-		strVal, ok := v.(string)
-		if !ok {
-			log.Warn("ignoring non-string (%T) MBA allocation %v", v, v)
-			continue
-		}
-		if strings.HasSuffix(strVal, mbSuffixPct) {
-			if !info.mb.mbpsEnabled {
-				value, err := strconv.ParseUint(strings.TrimSuffix(strVal, mbSuffixPct), 10, 7)
-				if err != nil {
-					return 0, err
-				}
-				return value, nil
-			}
-		} else if strings.HasSuffix(strVal, mbSuffixMbps) {
-			if info.mb.mbpsEnabled {
-				value, err := strconv.ParseUint(strings.TrimSuffix(strVal, mbSuffixMbps), 10, 32)
-				if err != nil {
-					return 0, err
-				}
-				return value, nil
-			}
-		} else {
-			log.Warn("unrecognized MBA allocation unit in %q", strVal)
-		}
-	}
-
-	// No value for the active mode was specified
-	if info.mb.mbpsEnabled {
-		return 0, fmt.Errorf("missing 'MBps' value from mbSchema; required because 'mba_MBps' is enabled in the system")
-	}
-	return 0, fmt.Errorf("missing '%%' value from mbSchema; required because percentage-based MBA allocation is enabled in the system")
 }

--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Intel Corporation
+Copyright 2019-2021 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Intel Corporation
+Copyright 2019-2021 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ partitions:
       all: [100%]
     classes:
       Guaranteed:
-        l3schema:
+        l3Allocation:
           all: 100%
   default:
     l3Allocation:
@@ -135,14 +135,14 @@ partitions:
       all: [100%]
     classes:
       Burstable:
-        l3schema:
+        l3Allocation:
           all: 100%
-        mbschema:
+        mbAllocation:
           all: [66%]
       BestEffort:
-        l3schema:
+        l3Allocation:
           all: 66%
-        mbschema:
+        mbAllocation:
           all: [33%]
 `
 
@@ -466,13 +466,13 @@ partitions:
       all: [100%]
     classes:
       class-1:
-        l3schema: 100%
+        l3Allocation: 100%
       class-2:
-        l3schema:
+        l3Allocation:
           all: 100%
           0-1: 10%
           2: "0x70"
-        mbschema:
+        mbAllocation:
           all: [40%]
           3: [10%]
   part-2:
@@ -486,16 +486,16 @@ partitions:
       2: [100%]
     classes:
       class-3:
-        l3schema: 100%
-        mbschema:
+        l3Allocation: 100%
+        mbAllocation:
           all: [40%]
           0: [80%]
       class-4:
-        l3schema: 50%
-        mbschema: [100%]
+        l3Allocation: 50%
+        mbAllocation: [100%]
       SYSTEM_DEFAULT:
-        l3schema: 60%
-        mbschema: [60%]
+        l3Allocation: 60%
+        mbAllocation: [60%]
   part-3:
     l3Allocation:
       all: 1%
@@ -504,8 +504,8 @@ partitions:
     mbAllocation: [20%]
     classes:
       class-5:
-        l3schema: 100%
-        mbschema:
+        l3Allocation: 100%
+        mbAllocation:
           all: [100%]
           0: [1%]
 `,
@@ -561,7 +561,7 @@ partitions:
     classes:
       class-2:
       SYSTEM_DEFAULT:
-        l3Schema:
+        l3Allocation:
           all: 100%
           3:
             unified: 80%
@@ -606,7 +606,7 @@ partitions:
     classes:
       class-2:
       SYSTEM_DEFAULT:
-        l3Schema:
+        l3Allocation:
           all: 100%
           3:
             unified: 80%
@@ -643,8 +643,8 @@ partitions:
     mbAllocation: [100%]
     classes:
       class-1:
-        l3schema: 20%
-        mbschema: [50%]
+        l3Allocation: 20%
+        mbAllocation: [50%]
 `,
 			schemata: map[string]Schemata{
 				"class-1": Schemata{
@@ -672,17 +672,6 @@ partitions:
 		},
 		// Testcase
 		TC{
-			name:        "Invalid allocation schema (fail)",
-			fs:          "resctrl.nomb",
-			configErrRe: `failed to parse L3 allocation request for partition "part-1": invalid structure of allocation schema`,
-			config: `
-partitions:
-  part-1:
-    l3Allocation: 0x12
-`,
-		},
-		// Testcase
-		TC{
 			name:        "Invalid cache ids (fail)",
 			fs:          "resctrl.nomb",
 			configErrRe: `failed to parse L3 allocation request for partition "part-1": rdt: invalid integer "a"`,
@@ -691,30 +680,6 @@ partitions:
   part-1:
     l3Allocation:
       a: 100%
-`,
-		},
-		// Testcase
-		TC{
-			name:        "L3 invalid allocation schema #1, invalid shorthand schema (fail)",
-			fs:          "resctrl.nomb",
-			configErrRe: `failed to parse L3 allocation request for partition "part-1": invalid structure of cache schema`,
-			config: `
-partitions:
-  part-1:
-    l3Allocation: [100%]
-`,
-		},
-		// Testcase
-		TC{
-			name:        "L3 invalid allocation schema #2, invalid per-type schema (fail)",
-			fs:          "resctrl.nomb",
-			configErrRe: `failed to parse L3 allocation request for partition "part-1": not a string value`,
-			config: `
-partitions:
-  part-1:
-    l3Allocation:
-      all:
-        unified: [100%]
 `,
 		},
 		// Testcase
@@ -769,7 +734,7 @@ partitions:
     l3Allocation: 100%
     classes:
       class-1:
-        l3schema: 20%
+        l3Allocation: 20%
 `,
 		},
 		// Testcase
@@ -786,8 +751,8 @@ partitions:
     mbAllocation: [100%]
     classes:
       class-1:
-        l3schema: 0-7
-        mbschema: [50%]
+        l3Allocation: 0-7
+        mbAllocation: [50%]
 `,
 			schemata: map[string]Schemata{
 				"class-1": Schemata{
@@ -809,7 +774,7 @@ partitions:
     mbAllocation: [100%]
     classes:
       class-1:
-        mbschema: [50%]
+        mbAllocation: [50%]
 `,
 		},
 		// Testcase
@@ -848,11 +813,11 @@ partitions:
     l3Allocation: 100%
     classes:
       class-1:
-        l3schema:
+        l3Allocation:
             all: 100%
             1: 50%
       class-2:
-        l3schema:
+        l3Allocation:
             all: 50%
             1: "0x7"
             2: "1-2"
@@ -1028,7 +993,7 @@ partitions:
     l3Allocation: "0xff00"
     classes:
       class-1:
-        l3schema: "0x1ff"
+        l3Allocation: "0x1ff"
 `,
 		},
 		// Testcase
@@ -1041,7 +1006,7 @@ partitions:
     l3Allocation: "100%"
     classes:
       class-1:
-        l3schema:
+        l3Allocation:
           all: "1%"
           1-2: "99-100%"
 `,
@@ -1065,7 +1030,7 @@ partitions:
     l3Allocation: "0xff00"
     classes:
       class-1:
-        l3schema: "0x1ff"
+        l3Allocation: "0x1ff"
 `,
 		},
 		// Testcase
@@ -1079,7 +1044,7 @@ partitions:
     l3Allocation: "100%"
     classes:
       class-1:
-        l3schema: "0-101%"
+        l3Allocation: "0-101%"
 `,
 		},
 		// Testcase
@@ -1092,7 +1057,7 @@ partitions:
   part-1:
     classes:
       class-1:
-        l3schema: "100%"
+        l3Allocation: "100%"
 `,
 		},
 		// Testcase
@@ -1105,7 +1070,7 @@ partitions:
     mbAllocation: ["1%"]
     classes:
       class-1:
-        mbSchema: ["100%"]
+        mbAllocation: ["100%"]
 `,
 			schemata: map[string]Schemata{
 				"class-1": Schemata{
@@ -1188,14 +1153,14 @@ partitions:
     l3Allocation: 50%
     classes:
       class-2:
-        l2Schema:
+        l2Allocation:
           all: 80%
           2:
             unified: 80%
             code: 60%
             data: 90%
       SYSTEM_DEFAULT:
-        l3Schema: 60%
+        l3Allocation: 60%
 
 `,
 			schemata: map[string]Schemata{
@@ -1230,7 +1195,7 @@ partitions:
     l3Allocation: 50%
     classes:
       class-1:
-        l2schema: 20%
+        l2Allocation: 20%
 `,
 			schemata: map[string]Schemata{
 				"class-1": Schemata{
@@ -1263,21 +1228,7 @@ partitions:
     mbAllocation: ["100%"]
     classes:
       class-1:
-        mbschema: ["1a%"]
-`,
-		},
-		// Testcase
-		TC{
-			name:        "MB class allocation not a list (fail)",
-			fs:          "resctrl.nol3",
-			configErrRe: `failed to resolve MB allocation for class "class-1": not a list value`,
-			config: `
-partitions:
-  part-1:
-    mbAllocation: ["100%"]
-    classes:
-      class-1:
-        mbschema: "100%"
+        mbAllocation: ["1a%"]
 `,
 		},
 		// Testcase
@@ -1301,7 +1252,7 @@ partitions:
   part-1:
     classes:
       class-1:
-        mbschema: ["100%"]
+        mbAllocation: ["100%"]
 `,
 		},
 		// Testcase
@@ -1315,7 +1266,7 @@ partitions:
     mbAllocation: ["50%", "1000MBps"]
     classes:
       class-1:
-        mbschema: ["100%", "1500MBps"]
+        mbAllocation: ["100%", "1500MBps"]
   part-2:
     mbAllocation:
       all: ["1000MBps"]
@@ -1323,7 +1274,7 @@ partitions:
       0,1: [50, "1GBps", "500MBps"]
     classes:
       class-2:
-        mbschema: ["750MBps"]
+        mbAllocation: ["750MBps"]
 `,
 			schemata: map[string]Schemata{
 				"class-1": Schemata{
@@ -1636,71 +1587,68 @@ func TestCacheAllocation(t *testing.T) {
 	}
 }
 
-func TestCatConfigParser(t *testing.T) {
-	p := newCatConfigParser(L3)
-	p.minBits = 2
-
+func TestParseCacheAllocationString(t *testing.T) {
 	// Test percentage
-	if a, err := p.parseString("10%"); err != nil {
+	if a, err := parseCacheAllocationString(2, "10%"); err != nil {
 		t.Errorf("unexpected error when parsing cache allocation: %v", err)
 	} else if a != catPctAllocation(10) {
 		t.Errorf("expected 10%% but got %d%%", a)
 	}
-	if _, err := p.parseString("1a%"); err == nil {
+	if _, err := parseCacheAllocationString(2, "1a%"); err == nil {
 		t.Errorf("unexpected success when parsing percentage cache allocation")
 	}
-	if _, err := p.parseString("101%"); err == nil {
+	if _, err := parseCacheAllocationString(2, "101%"); err == nil {
 		t.Errorf("unexpected success when parsing percentage cache allocation")
 	}
 
 	// Test percentage ranges
-	if a, err := p.parseString("10-20%"); err != nil {
+	if a, err := parseCacheAllocationString(2, "10-20%"); err != nil {
 		t.Errorf("unexpected error when parsing cache allocation: %v", err)
 	} else if a != (catPctRangeAllocation{lowPct: 10, highPct: 20}) {
 		t.Errorf("expected {10 20} but got %v", a)
 	}
-	if _, err := p.parseString("a-100%"); err == nil {
+	if _, err := parseCacheAllocationString(2, "a-100%"); err == nil {
 		t.Errorf("unexpected success when parsing percentage range cache allocation")
 	}
-	if _, err := p.parseString("0-1f%"); err == nil {
+	if _, err := parseCacheAllocationString(2, "0-1f%"); err == nil {
 		t.Errorf("unexpected success when parsing percentage range cache allocation")
 	}
-	if _, err := p.parseString("20-10%"); err == nil {
+	if _, err := parseCacheAllocationString(2, "20-10%"); err == nil {
 		t.Errorf("unexpected success when parsing percentage range cache allocation")
 	}
-	if _, err := p.parseString("20-101%"); err == nil {
+	if _, err := parseCacheAllocationString(2, "20-101%"); err == nil {
 		t.Errorf("unexpected success when parsing percentage range cache allocation")
 	}
 
 	// Test bitmask
-	if a, err := p.parseString("0xf0"); err != nil {
+	if a, err := parseCacheAllocationString(2, "0xf0"); err != nil {
 		t.Errorf("unexpected error when parsing cache allocation: %v", err)
 	} else if a != catAbsoluteAllocation(0xf0) {
 		t.Errorf("expected 0xf0 but got %#x", a)
 	}
-	if _, err := p.parseString("0x40"); err == nil {
+	if _, err := parseCacheAllocationString(2, "0x40"); err == nil {
 		t.Errorf("unexpected success when parsing bitmask cache allocation")
 	}
-	if _, err := p.parseString("0x11"); err == nil {
+	if _, err := parseCacheAllocationString(2, "0x11"); err == nil {
 		t.Errorf("unexpected success when parsing bitmask cache allocation")
 	}
-	if _, err := p.parseString("0xg"); err == nil {
+	if _, err := parseCacheAllocationString(2, "0xg"); err == nil {
 		t.Errorf("unexpected success when parsing bitmask cache allocation")
 	}
 
 	// Test bit numbers
-	if a, err := p.parseString("3,4,5-7,8"); err != nil {
+	if a, err := parseCacheAllocationString(2, "3,4,5-7,8"); err != nil {
 		t.Errorf("unexpected error when parsing cache allocation: %v", err)
 	} else if a != catAbsoluteAllocation(0x1f8) {
 		t.Errorf("expected 0x1f8 but got %#x", a)
 	}
-	if _, err := p.parseString("3,5"); err == nil {
+	if _, err := parseCacheAllocationString(2, "3,5"); err == nil {
 		t.Errorf("unexpected success when parsing bitmask cache allocation")
 	}
-	if _, err := p.parseString("1"); err == nil {
+	if _, err := parseCacheAllocationString(2, "1"); err == nil {
 		t.Errorf("unexpected success when parsing bitmask cache allocation")
 	}
-	if _, err := p.parseString("3-x"); err == nil {
+	if _, err := parseCacheAllocationString(2, "3-x"); err == nil {
 		t.Errorf("unexpected success when parsing bitmask cache allocation")
 	}
 }


### PR DESCRIPTION
Get rid of the obscure empty interfaces. Also, rename the xSchema fields
in the class configuration to xAllocation for consisntency with the
partition configuration.

The dropped negative test cases are now handled at JSON unmarshal time.