### PR TITLE
rdt: unexport bitmask type

### DIFF
--- a/pkg/rdt/bitmask.go
+++ b/pkg/rdt/bitmask.go
@@ -23,17 +23,17 @@ import (
 	"strings"
 )
 
-// Bitmask represents a generic 64 bit wide bitmask
-type Bitmask uint64
+// bitmask represents a generic 64 bit wide bitmask
+type bitmask uint64
 
 // MarshalJSON implements the Marshaler interface of "encoding/json"
-func (b Bitmask) MarshalJSON() ([]byte, error) {
+func (b bitmask) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("\"%#x\"", b)), nil
 }
 
-// ListStr prints the bitmask in human-readable format, similar to e.g. the
+// listStr prints the bitmask in human-readable format, similar to e.g. the
 // cpuset format of the Linux kernel
-func (b Bitmask) ListStr() string {
+func (b bitmask) listStr() string {
 	str := ""
 	sep := ""
 
@@ -66,10 +66,10 @@ func (b Bitmask) ListStr() string {
 	return str
 }
 
-// ListStrToBitmask parses a string containing a human-readable list of bit
+// listStrToBitmask parses a string containing a human-readable list of bit
 // numbers into a bitmask
-func ListStrToBitmask(str string) (Bitmask, error) {
-	b := Bitmask(0)
+func listStrToBitmask(str string) (bitmask, error) {
+	b := bitmask(0)
 
 	// Empty bitmask
 	if len(str) == 0 {
@@ -101,18 +101,18 @@ func ListStrToBitmask(str string) (Bitmask, error) {
 	return b, nil
 }
 
-func (b Bitmask) lsbOne() int {
+func (b bitmask) lsbOne() int {
 	if b == 0 {
 		return -1
 	}
 	return bits.TrailingZeros64(uint64(b))
 }
 
-func (b Bitmask) msbOne() int {
+func (b bitmask) msbOne() int {
 	// Returns -1 for b == 0
 	return 63 - bits.LeadingZeros64(uint64(b))
 }
 
-func (b Bitmask) lsbZero() int {
+func (b bitmask) lsbZero() int {
 	return bits.TrailingZeros64(^uint64(b))
 }

--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -52,9 +52,9 @@ type catInfoAll struct {
 }
 
 type catInfo struct {
-	cbmMask       Bitmask
+	cbmMask       bitmask
 	minCbmBits    uint64
-	shareableBits Bitmask
+	shareableBits bitmask
 }
 
 type l3MonInfo struct {
@@ -83,12 +83,12 @@ func (i catInfoAll) getInfo() catInfo {
 	return i.unified
 }
 
-func (i catInfoAll) cbmMask() Bitmask {
+func (i catInfoAll) cbmMask() bitmask {
 	mask := i.getInfo().cbmMask
 	if mask != 0 {
 		return mask
 	}
-	return Bitmask(^uint64(0))
+	return bitmask(^uint64(0))
 }
 
 func (i catInfoAll) minCbmBits() uint64 {
@@ -325,14 +325,14 @@ func readFileUint64(path string) (uint64, error) {
 	return strconv.ParseUint(data, 10, 64)
 }
 
-func readFileBitmask(path string) (Bitmask, error) {
+func readFileBitmask(path string) (bitmask, error) {
 	data, err := readFileString(path)
 	if err != nil {
 		return 0, err
 	}
 
 	value, err := strconv.ParseUint(data, 16, 64)
-	return Bitmask(value), err
+	return bitmask(value), err
 }
 
 func readFileString(path string) (string, error) {

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -1447,7 +1447,7 @@ partitions:
 
 func TestBitMap(t *testing.T) {
 	// Test ListStr()
-	testSet := map[Bitmask]string{
+	testSet := map[bitmask]string{
 		0x0:                "",
 		0x1:                "0",
 		0x2:                "1",
@@ -1459,13 +1459,13 @@ func TestBitMap(t *testing.T) {
 	}
 	for i, s := range testSet {
 		// Test conversion to string
-		listStr := i.ListStr()
+		listStr := i.listStr()
 		if listStr != s {
 			t.Errorf("from %#x expected %q, got %q", i, s, listStr)
 		}
 
 		// Test conversion from string
-		b, err := ListStrToBitmask(s)
+		b, err := listStrToBitmask(s)
 		if err != nil {
 			t.Errorf("unexpected err when converting %q: %v", s, err)
 		}
@@ -1492,14 +1492,14 @@ func TestBitMap(t *testing.T) {
 		"1,2,3-",
 	}
 	for _, s := range negTestSet {
-		b, err := ListStrToBitmask(s)
+		b, err := listStrToBitmask(s)
 		if err == nil {
 			t.Errorf("expected err but got %#x when converting %q", b, s)
 		}
 	}
 
 	// Test MarshalJSON
-	if s, err := Bitmask(10).MarshalJSON(); err != nil {
+	if s, err := bitmask(10).MarshalJSON(); err != nil {
 	} else if string(s) != `"0xa"` {
 		t.Errorf(`expected "0xa" but returned %s`, s)
 	}


### PR DESCRIPTION
Bitmask is not part of the public API, just an internal helper type.