### PR TITLE
rdt: add Kubernetes helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ partitions:
         mbAllocation:
           # MB allocation spec of the class
           <cache-ids>: <mb-allocation-spec>
+
+        # Settings for the Kubernetes helper functions. Have no effect on the resctrl
+        # configuration and control interface.
+        kubernetes:
+          # Set to true to deny assigning to this class via container annotation
+          denyContainerAnnotation: [true|false]
+          # Set to true to deny assigning to this class via pod annotation
+          denyPodAnnotation: [true|false]
 ```
 
 | Field | Format | Example | Description |

--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -820,6 +820,9 @@ func (c *Config) resolveClasses() (classSet, error) {
 				gname = RootClassName
 			}
 
+			if !IsQualifiedClassName(gname) {
+				return classes, fmt.Errorf("unqualified class name %q (must not be '.' or '..' and must not contain '/' or newline)", gname)
+			}
 			if _, ok := classes[gname]; ok {
 				return classes, fmt.Errorf("class names must be unique, %q defined multiple times", gname)
 			}

--- a/pkg/rdt/kubernetes.go
+++ b/pkg/rdt/kubernetes.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdt
+
+import (
+	"fmt"
+)
+
+const (
+	// RdtContainerAnnotation is the CRI level container annotation for setting
+	// the RDT class (CLOS) of a container
+	RdtContainerAnnotation = "io.kubernetes.cri.rdt-class"
+
+	// RdtPodAnnotation is a Pod annotation for setting the RDT class (CLOS) of
+	// all containers of the pod
+	RdtPodAnnotation = "rdt.resources.beta.kubernetes.io/pod"
+
+	// RdtPodAnnotationContainerPrefix is prefix for per-container Pod annotation
+	// for setting the RDT class (CLOS) of one container of the pod
+	RdtPodAnnotationContainerPrefix = "rdt.resources.beta.kubernetes.io/container."
+)
+
+// ContainerClassFromAnnotations determines the effective RDT class of a
+// container from the Pod annotations and CRI level container annotations of a
+// container. Verifies that the class exists in goresctrl configuration and that
+// it is allowed to be used.
+func ContainerClassFromAnnotations(containerName string, containerAnnotations, podAnnotations map[string]string) (string, error) {
+	if rdt == nil {
+		return "", fmt.Errorf("RDT not initialized")
+	}
+
+	fromPodAnnotation := false
+	clsName, ok := containerAnnotations[RdtContainerAnnotation]
+	if !ok {
+		fromPodAnnotation = true
+		clsName, ok = podAnnotations[RdtPodAnnotationContainerPrefix+containerName]
+
+		if !ok {
+			clsName, ok = podAnnotations[RdtPodAnnotation]
+		}
+	}
+
+	if ok {
+		// Verify validity of class name
+		if !IsQualifiedClassName(clsName) {
+			return "", fmt.Errorf("unqualified RDT class name %q", clsName)
+		}
+
+		// If RDT has been initialized we check that the class exists
+		if _, ok := rdt.getClass(clsName); !ok {
+			return "", fmt.Errorf("RDT class %q does not exist in configuration", clsName)
+		}
+
+		// If classes have been configured by goresctrl
+		if clsConf, ok := rdt.conf.Classes[unaliasClassName(clsName)]; ok {
+			// Check that the class is allowed
+			if fromPodAnnotation && clsConf.Kubernetes.DenyPodAnnotation {
+				return "", fmt.Errorf("RDT class %q not allowed from Pod annotations", clsName)
+			} else if !fromPodAnnotation && clsConf.Kubernetes.DenyContainerAnnotation {
+				return "", fmt.Errorf("RDT class %q not allowed from Container annotation", clsName)
+			}
+		}
+	}
+
+	return clsName, nil
+}

--- a/pkg/rdt/kubernetes_test.go
+++ b/pkg/rdt/kubernetes_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rdt
+
+import (
+	"testing"
+)
+
+func TestContainerClassFromAnnotations(t *testing.T) {
+	mockRdt := &control{
+		classes: make(map[string]*ctrlGroup),
+	}
+
+	containerName := "test-container"
+	containerAnnotations := map[string]string{RdtContainerAnnotation: "class-1"}
+	podAnnotations := map[string]string{
+		RdtPodAnnotationContainerPrefix + containerName: "class-2",
+		RdtPodAnnotation: "class-3"}
+
+	// Helper function for checking test cases
+	tc := func(expectError bool, expectedClsName string) {
+		cls, err := ContainerClassFromAnnotations(containerName, containerAnnotations, podAnnotations)
+		if !expectError && err != nil {
+			t.Errorf("unexpected error: %v", err)
+		} else if expectError && err == nil {
+			t.Errorf("unexpected success setting RDT class to %q", cls)
+		} else if cls != expectedClsName {
+			t.Errorf("invalid rdt class, expecting %q, got %q", expectedClsName, cls)
+		}
+	}
+
+	//
+	// 1. Test container annotation
+	//
+	rdt = nil
+	tc(true, "")
+
+	// Mock configured rdt which enables the functionality
+	rdt = mockRdt
+
+	// Should fail with an empty set of classes
+	tc(true, "")
+
+	// Should succeed when the class exists but no configuration has been set ("discovery mode")
+	mockRdt.classes = map[string]*ctrlGroup{"": nil, "class-1": nil, "class-2": nil, "class-3": nil}
+	tc(false, "class-1")
+
+	// Should succeed with default class config
+	mockRdt.conf.Classes = classSet{"class-1": &classConfig{}, "class-2": &classConfig{}, "class-3": &classConfig{}}
+	tc(false, "class-1")
+
+	// Should fail when container annotation has been denied in class ocnfig
+	mockRdt.conf.Classes["class-1"].Kubernetes.DenyContainerAnnotation = true
+	tc(true, "")
+
+	// Test invalid class name
+	containerAnnotations[RdtContainerAnnotation] = "foo/bar"
+	tc(true, "")
+
+	//
+	// 2. Test per-container Pod annotation
+	//
+	delete(containerAnnotations, RdtContainerAnnotation)
+	tc(false, "class-2")
+
+	// Should fail when pod annotations for the class are denied
+	mockRdt.conf.Classes["class-2"].Kubernetes.DenyPodAnnotation = true
+	tc(true, "")
+
+	//
+	// 3. Test pod-wide Pod annotation
+	//
+	delete(podAnnotations, RdtPodAnnotationContainerPrefix+containerName)
+	tc(false, "class-3")
+
+	// Should fail when pod annotations for the class are denied
+	mockRdt.conf.Classes["class-3"].Kubernetes.DenyPodAnnotation = true
+	tc(true, "")
+
+	//
+	// Test empty annotations
+	//
+	delete(podAnnotations, RdtPodAnnotation)
+	tc(false, "")
+}

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -301,10 +301,7 @@ func IsQualifiedClassName(name string) bool {
 }
 
 func (c *control) getClass(name string) (CtrlGroup, bool) {
-	if isRootClass(name) {
-		name = RootClassName
-	}
-	cls, ok := c.classes[name]
+	cls, ok := c.classes[unaliasClassName(name)]
 	return cls, ok
 }
 
@@ -852,4 +849,11 @@ func resctrlGroupsFromFs(prefix string, path string) ([]string, error) {
 
 func isRootClass(name string) bool {
 	return name == RootClassName || name == RootClassAlias
+}
+
+func unaliasClassName(name string) string {
+	if isRootClass(name) {
+		return RootClassName
+	}
+	return name
 }

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -294,6 +294,12 @@ func GetMonFeatures() map[MonResource][]string {
 	return map[MonResource][]string{}
 }
 
+// IsQualifiedClassName returns true if given string qualifies as a class name
+func IsQualifiedClassName(name string) bool {
+	// Must be qualified as a file name
+	return len(name) < 4096 && name != "." && name != ".." && !strings.ContainsAny(name, "/\n")
+}
+
 func (c *control) getClass(name string) (CtrlGroup, bool) {
 	if isRootClass(name) {
 		name = RootClassName

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -146,6 +146,10 @@ partitions:
           all: 66%
         mbAllocation:
           all: [33%]
+        kubernetes:
+          denyPodAnnotation: true
+kubernetes:
+  allowedPodAnnotationClasses: [bar, foo]
 `
 
 	verifyGroupNames := func(a interface{}, b []string) {
@@ -180,6 +184,7 @@ partitions:
 	//
 	// 1. test uninitialized interface
 	//
+	rdt = nil
 	SetLogger(grclog.NewLoggerWrapper(stdlog.New(os.Stderr, "[ rdt-test-1 ] ", 0)))
 
 	if err := SetConfig(&Config{}, false); err == nil {
@@ -242,6 +247,11 @@ partitions:
 	// Forced configuration should succeed
 	if err := SetConfigFromFile(testConfigFile, true); err != nil {
 		t.Fatalf("rdt forced configuration failed: %v", err)
+	}
+
+	// Check that KubernetesOptions of classes are parsed and propagated correctly
+	if !rdt.conf.Classes["BestEffort"].Kubernetes.DenyPodAnnotation {
+		t.Fatal("DenyPodAnnotation of class BestEffort should be 'true'")
 	}
 
 	// Check that SetLogger() takes effect in the control interface, too

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -699,6 +699,18 @@ partitions:
 		},
 		// Testcase
 		TC{
+			name:        "invalid class name",
+			fs:          "resctrl.nomb",
+			configErrRe: `unqualified class name`,
+			config: `
+partitions:
+  part-1:
+    classes:
+      "..":
+`,
+		},
+		// Testcase
+		TC{
 			name:        "Invalid cache ids (fail)",
 			fs:          "resctrl.nomb",
 			configErrRe: `failed to parse L3 allocation request for partition "part-1": invalid integer "a"`,
@@ -1677,5 +1689,23 @@ func TestCacheProportion(t *testing.T) {
 	}
 	if _, err := CacheProportion("3-x").parse(2); err == nil {
 		t.Errorf("unexpected success when parsing bitmask cache allocation")
+	}
+}
+
+func TestIsQualifiedClassName(t *testing.T) {
+	tcs := map[string]bool{
+		"foo":          true,
+		RootClassName:  true,
+		RootClassAlias: true,
+		".":            false,
+		"..":           false,
+		"foo/bar":      false,
+		"foo\n":        false,
+	}
+
+	for name, expected := range tcs {
+		if r := IsQualifiedClassName(name); r != expected {
+			t.Errorf("IsQualifiedClassName(%q) returned %v (expected %v)", name, r, expected)
+		}
 	}
 }


### PR DESCRIPTION
Add ContainerClassFromAnnotations() for retrieving the effective RDT
class of a container from its annotations (container annotations and pod
annotations).

Also, add new per-class configuration options for controlling if a class
may be set via container and pod annotations. Example:

```
partitions:
  my-part:
    classes:
      my-class:
        kubernetes:
          denyContainerAnnotation: false
          denyPodAnnotation: true
```

The 'kubernetes' settings have no effect on resctrl configuration but is
only used when excercising the k8s releated helper functionality,
currently ContainerClassFromAnnotations().

Based on #47 