### PR TITLE
rdt: change the name of the root class to system/default

### DIFF
--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -64,7 +64,7 @@ import (
 const (
 	// RootClassName is the name we use in our config for the special class
 	// that configures the "root" resctrl group of the system
-	RootClassName = "DEFAULT"
+	RootClassName = "system/default"
 	// RootClassAlias is an alternative name for the root class
 	RootClassAlias = ""
 )
@@ -297,7 +297,7 @@ func GetMonFeatures() map[MonResource][]string {
 // IsQualifiedClassName returns true if given string qualifies as a class name
 func IsQualifiedClassName(name string) bool {
 	// Must be qualified as a file name
-	return len(name) < 4096 && name != "." && name != ".." && !strings.ContainsAny(name, "/\n")
+	return name == RootClassName || (len(name) < 4096 && name != "." && name != ".." && !strings.ContainsAny(name, "/\n"))
 }
 
 func (c *control) getClass(name string) (CtrlGroup, bool) {

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -219,9 +219,9 @@ kubernetes:
 
 	// Check that existing groups were read correctly on init
 	classes := GetClasses()
-	verifyGroupNames(classes, []string{"Guaranteed", "DEFAULT", "Stale"})
+	verifyGroupNames(classes, []string{"Guaranteed", "Stale", RootClassName})
 
-	cls, _ := GetClass("DEFAULT")
+	cls, _ := GetClass(RootClassName)
 	verifyGroupNames(cls.GetMonGroups(), []string{})
 	cls, _ = GetClass("Guaranteed")
 	verifyGroupNames(cls.GetMonGroups(), []string{"predefined_group_live"})
@@ -289,7 +289,7 @@ kubernetes:
 
 	// Verify GetClasses
 	classes = GetClasses()
-	verifyGroupNames(classes, []string{"BestEffort", "Burstable", "Guaranteed", "DEFAULT"})
+	verifyGroupNames(classes, []string{"BestEffort", "Burstable", "Guaranteed", RootClassName})
 
 	// Verify assigning pids to classes (ctrl groups)
 	cls, _ = GetClass("Guaranteed")
@@ -436,19 +436,19 @@ kubernetes:
 		t.Fatalf("DiscoverClasses() failed unexpectedly")
 	}
 	classes = GetClasses()
-	verifyGroupNames(classes, []string{"Guaranteed", "non_goresctrl.Group", "DEFAULT"})
+	verifyGroupNames(classes, []string{"Guaranteed", "non_goresctrl.Group", RootClassName})
 
 	if err := DiscoverClasses("non_goresctrl."); err != nil {
 		t.Fatalf("DiscoverClasses() failed unexpectedly")
 	}
 	classes = GetClasses()
-	verifyGroupNames(classes, []string{"Group", "DEFAULT"})
+	verifyGroupNames(classes, []string{"Group", RootClassName})
 
 	if err := DiscoverClasses("non-existing-prefix"); err != nil {
 		t.Fatalf("DiscoverClasses() failed unexpectedly")
 	}
 	classes = GetClasses()
-	verifyGroupNames(classes, []string{"DEFAULT"})
+	verifyGroupNames(classes, []string{RootClassName})
 }
 
 // TestConfig tests configuration parsing and resolving
@@ -515,7 +515,7 @@ partitions:
       class-4:
         l3Allocation: 50%
         mbAllocation: [100%]
-      DEFAULT:
+      system/default:
         l3Allocation: 60%
         mbAllocation: [60%]
   part-3:
@@ -548,7 +548,7 @@ partitions:
 					l3: "0=f000;1=3f;2=f;3=f000",
 					mb: "0=50;1=80;2=100;3=50",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3: "0=1f000;1=7f;2=1f;3=1f000",
 					mb: "0=30;1=48;2=60;3=30",
 				},
@@ -582,7 +582,7 @@ partitions:
       2,3: 60%
     classes:
       class-2:
-      DEFAULT:
+      system/default:
         l3Allocation:
           all: 100%
           3:
@@ -598,7 +598,7 @@ partitions:
 				"class-2": Schemata{
 					l3: "0=ff000;1=ff000;2=fff00;3=fff00",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3: "0=ff000;1=ff000;2=fff00;3=3ff00",
 				},
 			},
@@ -645,7 +645,7 @@ partitions:
 					l3code: "0=fc000;1=fc000;2=fff00;3=fff00",
 					l3data: "0=ffc00;1=ffc00;2=fff00;3=fff00",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3code: "0=fc000;1=fc000;2=fff00;3=ff00",
 					l3data: "0=ffc00;1=ffc00;2=fff00;3=7ff00",
 				},
@@ -672,7 +672,7 @@ partitions:
 				"class-1": Schemata{
 					mb: "0=50;1=50;2=50;3=50",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					mb: "0=100;1=100;2=100;3=100",
 				},
 			},
@@ -696,7 +696,7 @@ partitions:
 		TC{
 			name:        "duplicate root class (fail)",
 			fs:          "resctrl.nomb",
-			configErrRe: `"DEFAULT" defined multiple times`,
+			configErrRe: `"system/default" defined multiple times`,
 			config: `
 partitions:
   part-1:
@@ -704,7 +704,7 @@ partitions:
       "":
   part-2:
     classes:
-      DEFAULT:
+      system/default:
 `,
 		},
 		// Testcase
@@ -807,7 +807,7 @@ partitions:
 				"class-1": Schemata{
 					l3: "0=ff;1=ff;2=ff;3=ff",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
 				},
 			},
@@ -878,7 +878,7 @@ partitions:
 				"class-2": Schemata{
 					l3: "0=3ff;1=7;2=6;3=3ff",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
 				},
 			},
@@ -913,7 +913,7 @@ partitions:
 				"class-2": Schemata{
 					l3: "0=3f0;1=300;2=e000;3=c0000",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
 				},
 			},
@@ -1063,7 +1063,7 @@ partitions:
 				"class-1": Schemata{
 					l3: "0=3;1=c0000;2=c0000;3=3",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
 				},
 			},
@@ -1125,7 +1125,7 @@ partitions:
 				"class-1": Schemata{
 					mb: "0=10;1=10;2=10;3=10",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					mb: "0=100;1=100;2=100;3=100",
 				},
 			},
@@ -1154,7 +1154,7 @@ partitions:
       0: 40%
       1: 5%
     classes:
-      DEFAULT:
+      system/default:
 `,
 			schemata: map[string]Schemata{
 				"class-1": Schemata{
@@ -1163,7 +1163,7 @@ partitions:
 				"class-2": Schemata{
 					l2: "0=c;1=40",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l2: "0=f0;1=80",
 				},
 			},
@@ -1208,7 +1208,7 @@ partitions:
             unified: 80%
             code: 60%
             data: 90%
-      DEFAULT:
+      system/default:
         l3Allocation: 60%
 
 `,
@@ -1223,7 +1223,7 @@ partitions:
 					l2data: "0=ff00;1=ff00;2=fc00;3=3fc00",
 					l3:     "0=1f8",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l2code: "0=1ff00;1=1ff00;2=ff0;3=fff00",
 					l2data: "0=1ff00;1=1ff00;2=fc00;3=ffc00",
 					l3:     "0=78",
@@ -1250,7 +1250,7 @@ partitions:
 				"class-1": Schemata{
 					l3: "0=3ff;1=3ff;2=3ff;3=3ff",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
 				},
 			},
@@ -1332,7 +1332,7 @@ partitions:
 				"class-2": Schemata{
 					mb: "0=500;1=500;2=750;3=750",
 				},
-				"DEFAULT": Schemata{
+				"system/default": Schemata{
 					mb: "0=4294967295;1=4294967295;2=4294967295;3=4294967295",
 				},
 			},


### PR DESCRIPTION
Make naming unambiguos/non-overlapping by using something that can't be
a subdir name under /sys/fs/resctrl.

Based on #47