### PR TITLE
rdt: make ContainerClassFromAnnotations() bit more relaxed

### DIFF
--- a/pkg/rdt/kubernetes.go
+++ b/pkg/rdt/kubernetes.go
@@ -39,10 +39,6 @@ const (
 // container. Verifies that the class exists in goresctrl configuration and that
 // it is allowed to be used.
 func ContainerClassFromAnnotations(containerName string, containerAnnotations, podAnnotations map[string]string) (string, error) {
-	if rdt == nil {
-		return "", fmt.Errorf("RDT not initialized")
-	}
-
 	fromPodAnnotation := false
 	clsName, ok := containerAnnotations[RdtContainerAnnotation]
 	if !ok {
@@ -55,6 +51,10 @@ func ContainerClassFromAnnotations(containerName string, containerAnnotations, p
 	}
 
 	if ok {
+		if rdt == nil {
+			return "", fmt.Errorf("RDT not initialized, class %q not available", clsName)
+		}
+
 		// Verify validity of class name
 		if !IsQualifiedClassName(clsName) {
 			return "", fmt.Errorf("unqualified RDT class name %q", clsName)

--- a/pkg/rdt/kubernetes_test.go
+++ b/pkg/rdt/kubernetes_test.go
@@ -26,10 +26,8 @@ func TestContainerClassFromAnnotations(t *testing.T) {
 	}
 
 	containerName := "test-container"
-	containerAnnotations := map[string]string{RdtContainerAnnotation: "class-1"}
-	podAnnotations := map[string]string{
-		RdtPodAnnotationContainerPrefix + containerName: "class-2",
-		RdtPodAnnotation: "class-3"}
+	containerAnnotations := map[string]string{}
+	podAnnotations := map[string]string{}
 
 	// Helper function for checking test cases
 	tc := func(expectError bool, expectedClsName string) {
@@ -46,7 +44,16 @@ func TestContainerClassFromAnnotations(t *testing.T) {
 	//
 	// 1. Test container annotation
 	//
+
+	// Should succeed when rdt is uninitialized but annotations are empty
 	rdt = nil
+	tc(false, "")
+
+	// Should fail when rdt is uninitialized but annotations point to a class
+	containerAnnotations = map[string]string{RdtContainerAnnotation: "class-1"}
+	podAnnotations = map[string]string{
+		RdtPodAnnotationContainerPrefix + containerName: "class-2",
+		RdtPodAnnotation: "class-3"}
 	tc(true, "")
 
 	// Mock configured rdt which enables the functionality


### PR DESCRIPTION
Make ContainerClassFromAnnotations() fall-through without an error even
if rdt has not been initialized in the case that no rdt-related
annotations are present. If no rdt annotation has been specified we
should not care whether rdt has been actually initialized or not as it's
sort of "no-op".