### PR TITLE
blockio: add ContainerClassFromAnnotations

### DIFF
--- a/pkg/blockio/kubernetes.go
+++ b/pkg/blockio/kubernetes.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockio
+
+import (
+	"github.com/intel/goresctrl/pkg/kubernetes"
+)
+
+// ContainerClassFromAnnotations determines the effective blockio
+// class of a container from the Pod annotations and CRI level
+// container annotations of a container. If the class is not specified
+// by any annotation, returns empty class name. Returned error is
+// reserved (nil).
+func ContainerClassFromAnnotations(containerName string, containerAnnotations, podAnnotations map[string]string) (string, error) {
+	clsName, _ := kubernetes.ContainerClassFromAnnotations(
+		kubernetes.BlockioContainerAnnotation, kubernetes.BlockioPodAnnotation, kubernetes.BlockioPodAnnotationContainerPrefix,
+		containerName, containerAnnotations, podAnnotations)
+	return clsName, nil
+}

--- a/pkg/kubernetes/annotations.go
+++ b/pkg/kubernetes/annotations.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+const (
+	// BlockioContainerAnnotation is the CRI level container annotation for setting
+	// the blockio class of a container
+	BlockioContainerAnnotation = "io.kubernetes.cri.blockio-class"
+
+	// BlockioPodAnnotation is a Pod annotation for setting the blockio class of
+	// all containers of the pod
+	BlockioPodAnnotation = "blockio.resources.beta.kubernetes.io/pod"
+
+	// BlockioPodAnnotationContainerPrefix is prefix for per-container Pod annotation
+	// for setting the blockio class of one container of the pod
+	BlockioPodAnnotationContainerPrefix = "blockio.resources.beta.kubernetes.io/container."
+
+	// RdtContainerAnnotation is the CRI level container annotation for setting
+	// the RDT class (CLOS) of a container
+	RdtContainerAnnotation = "io.kubernetes.cri.rdt-class"
+
+	// RdtPodAnnotation is a Pod annotation for setting the RDT class (CLOS) of
+	// all containers of the pod
+	RdtPodAnnotation = "rdt.resources.beta.kubernetes.io/pod"
+
+	// RdtPodAnnotationContainerPrefix is prefix for per-container Pod annotation
+	// for setting the RDT class (CLOS) of one container of the pod
+	RdtPodAnnotationContainerPrefix = "rdt.resources.beta.kubernetes.io/container."
+)
+
+type ClassOrigin int
+
+const (
+	ClassOriginNotFound ClassOrigin = iota
+	ClassOriginContainerAnnotation
+	ClassOriginPodAnnotation
+)
+
+func (c ClassOrigin) String() string {
+	switch c {
+	case ClassOriginNotFound:
+		return "<not found>"
+	case ClassOriginContainerAnnotation:
+		return "container annotations"
+	case ClassOriginPodAnnotation:
+		return "pod annotations"
+	default:
+		return "<unknown>"
+	}
+}
+
+// ContainerClassFromAnnotations determines the effective class of a
+// container from the Pod annotations and CRI level container
+// annotations of a container.
+func ContainerClassFromAnnotations(containerAnnotation, podAnnotation, podAnnotationContainerPrefix string, containerName string, containerAnnotations, podAnnotations map[string]string) (string, ClassOrigin) {
+	if clsName, ok := containerAnnotations[containerAnnotation]; ok {
+		return clsName, ClassOriginContainerAnnotation
+	}
+	if clsName, ok := podAnnotations[podAnnotationContainerPrefix+containerName]; ok {
+		return clsName, ClassOriginPodAnnotation
+	}
+	if clsName, ok := podAnnotations[podAnnotation]; ok {
+		return clsName, ClassOriginPodAnnotation
+	}
+	return "", ClassOriginNotFound
+}

--- a/pkg/kubernetes/annotations_test.go
+++ b/pkg/kubernetes/annotations_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+)
+
+// TestContainerClassFromAnnotations: unit test for ContainerClassFromAnnotations.
+func TestContainerClassFromAnnotations(t *testing.T) {
+	allContainerAnnotations := map[string]string{
+		BlockioContainerAnnotation: "blockio-container-class",
+		RdtContainerAnnotation:     "rdt-container-class",
+	}
+	allPodAnnotations := map[string]string{
+		BlockioPodAnnotation: "blockio-pod-class",
+		BlockioPodAnnotationContainerPrefix + "special-container": "blockio-pod-container-class",
+		RdtPodAnnotation: "rdt-pod-class",
+		RdtPodAnnotationContainerPrefix + "special-container": "rdt-pod-container-class",
+	}
+	tcases := []struct {
+		name string // the name of the test case
+		// inputs
+		lookForCA  string            // container annotation to look for
+		lookForPA  string            // pod annotation to look for
+		lookForPAC string            // pod annotation container prefix to look for
+		cName      string            // container name
+		cAnns      map[string]string // container annotations
+		pAnns      map[string]string // pod annotations
+		// outputs
+		expectedClass  string
+		expectedOrigin ClassOrigin
+	}{
+		{
+			name:           "all empty",
+			expectedOrigin: ClassOriginNotFound,
+		},
+		{
+			name:           "container annotation overrides all pod annotations",
+			lookForCA:      BlockioContainerAnnotation,
+			lookForPA:      BlockioPodAnnotation,
+			lookForPAC:     BlockioPodAnnotationContainerPrefix,
+			cName:          "special-container",
+			cAnns:          allContainerAnnotations,
+			pAnns:          allPodAnnotations,
+			expectedClass:  "blockio-container-class",
+			expectedOrigin: ClassOriginContainerAnnotation,
+		},
+		{
+			name:           "container prefix overrides default pod annotation",
+			lookForCA:      "not.existing.container.annotation",
+			lookForPA:      RdtPodAnnotation,
+			lookForPAC:     RdtPodAnnotationContainerPrefix,
+			cName:          "special-container",
+			cAnns:          allContainerAnnotations,
+			pAnns:          allPodAnnotations,
+			expectedClass:  "rdt-pod-container-class",
+			expectedOrigin: ClassOriginPodAnnotation,
+		},
+		{
+			name:           "default pod annotation",
+			lookForCA:      "not.existing.container.annotation",
+			lookForPA:      RdtPodAnnotation,
+			lookForPAC:     RdtPodAnnotationContainerPrefix,
+			cName:          "ordinary-container",
+			cAnns:          allContainerAnnotations,
+			pAnns:          allPodAnnotations,
+			expectedClass:  "rdt-pod-class",
+			expectedOrigin: ClassOriginPodAnnotation,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			observedClass, observedOrigin := ContainerClassFromAnnotations(
+				tc.lookForCA, tc.lookForPA, tc.lookForPAC,
+				tc.cName, tc.cAnns, tc.pAnns)
+			if observedClass != tc.expectedClass {
+				t.Errorf("expected class %q, observed %q", tc.expectedClass, observedClass)
+			}
+			if observedOrigin != tc.expectedOrigin {
+				t.Errorf("expected origin %q, observed %q", tc.expectedOrigin, observedOrigin)
+			}
+		})
+	}
+
+}

--- a/pkg/rdt/kubernetes_test.go
+++ b/pkg/rdt/kubernetes_test.go
@@ -18,6 +18,8 @@ package rdt
 
 import (
 	"testing"
+
+	"github.com/intel/goresctrl/pkg/kubernetes"
 )
 
 func TestContainerClassFromAnnotations(t *testing.T) {
@@ -50,10 +52,10 @@ func TestContainerClassFromAnnotations(t *testing.T) {
 	tc(false, "")
 
 	// Should fail when rdt is uninitialized but annotations point to a class
-	containerAnnotations = map[string]string{RdtContainerAnnotation: "class-1"}
+	containerAnnotations = map[string]string{kubernetes.RdtContainerAnnotation: "class-1"}
 	podAnnotations = map[string]string{
-		RdtPodAnnotationContainerPrefix + containerName: "class-2",
-		RdtPodAnnotation: "class-3"}
+		kubernetes.RdtPodAnnotationContainerPrefix + containerName: "class-2",
+		kubernetes.RdtPodAnnotation:                                "class-3"}
 	tc(true, "")
 
 	// Mock configured rdt which enables the functionality
@@ -75,13 +77,13 @@ func TestContainerClassFromAnnotations(t *testing.T) {
 	tc(true, "")
 
 	// Test invalid class name
-	containerAnnotations[RdtContainerAnnotation] = "foo/bar"
+	containerAnnotations[kubernetes.RdtContainerAnnotation] = "foo/bar"
 	tc(true, "")
 
 	//
 	// 2. Test per-container Pod annotation
 	//
-	delete(containerAnnotations, RdtContainerAnnotation)
+	delete(containerAnnotations, kubernetes.RdtContainerAnnotation)
 	tc(false, "class-2")
 
 	// Should fail when pod annotations for the class are denied
@@ -91,7 +93,7 @@ func TestContainerClassFromAnnotations(t *testing.T) {
 	//
 	// 3. Test pod-wide Pod annotation
 	//
-	delete(podAnnotations, RdtPodAnnotationContainerPrefix+containerName)
+	delete(podAnnotations, kubernetes.RdtPodAnnotationContainerPrefix+containerName)
 	tc(false, "class-3")
 
 	// Should fail when pod annotations for the class are denied
@@ -101,6 +103,6 @@ func TestContainerClassFromAnnotations(t *testing.T) {
 	//
 	// Test empty annotations
 	//
-	delete(podAnnotations, RdtPodAnnotation)
+	delete(podAnnotations, kubernetes.RdtPodAnnotation)
 	tc(false, "")
 }


### PR DESCRIPTION
- Add pkg/kubernetes to implement common logic for annotation
  handling and annotation strings.
- Both blockio and rdt export their own ContainerClassFromAnnotations
  functions with the same interface. Users of these packages do not need
  pkg/kubernetes.
- Refactor rdt ContainerClassFromAnnotations to use the common logic.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>