### PR TITLE
blockio: add ContainerClassFromAnnotations

### DIFF
--- a/pkg/blockio/kubernetes.go
+++ b/pkg/blockio/kubernetes.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockio
+
+import (
+	"github.com/intel/goresctrl/pkg/kubernetes"
+)
+
+const (
+	// BlockioContainerAnnotation is the CRI level container annotation for setting
+	// the blockio class of a container
+	BlockioContainerAnnotation = "io.kubernetes.cri.blockio-class"
+
+	// BlockioPodAnnotation is a Pod annotation for setting the blockio class of
+	// all containers of the pod
+	BlockioPodAnnotation = "blockio.resources.beta.kubernetes.io/pod"
+
+	// BlockioPodAnnotationContainerPrefix is prefix for per-container Pod annotation
+	// for setting the blockio class of one container of the pod
+	BlockioPodAnnotationContainerPrefix = "blockio.resources.beta.kubernetes.io/container."
+)
+
+// ContainerClassFromAnnotations determines the effective blockio
+// class of a container from the Pod annotations and CRI level
+// container annotations of a container. If the class is not specified
+// by any annotation, returns empty class name. Returned error is
+// reserved (nil).
+func ContainerClassFromAnnotations(containerName string, containerAnnotations, podAnnotations map[string]string) (string, error) {
+	clsName, _ := kubernetes.ContainerClassFromAnnotations(
+		BlockioContainerAnnotation, BlockioPodAnnotation, BlockioPodAnnotationContainerPrefix,
+		containerName, containerAnnotations, podAnnotations)
+	return clsName, nil
+}

--- a/pkg/kubernetes/annotations.go
+++ b/pkg/kubernetes/annotations.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+// ClassOrigin type indicates the source of container's class
+// information: whether it is found from CRI level container
+// annotations, Kubernetes' pod annotations, or it has not been found
+// at all.
+type ClassOrigin int
+
+const (
+	ClassOriginNotFound ClassOrigin = iota
+	ClassOriginContainerAnnotation
+	ClassOriginPodAnnotation
+)
+
+func (c ClassOrigin) String() string {
+	switch c {
+	case ClassOriginNotFound:
+		return "<not found>"
+	case ClassOriginContainerAnnotation:
+		return "container annotations"
+	case ClassOriginPodAnnotation:
+		return "pod annotations"
+	default:
+		return "<unknown>"
+	}
+}
+
+// ContainerClassFromAnnotations determines the effective class of a
+// container from the Pod annotations and CRI level container
+// annotations of a container.
+func ContainerClassFromAnnotations(containerAnnotation, podAnnotation, podAnnotationContainerPrefix string, containerName string, containerAnnotations, podAnnotations map[string]string) (string, ClassOrigin) {
+	if clsName, ok := containerAnnotations[containerAnnotation]; ok {
+		return clsName, ClassOriginContainerAnnotation
+	}
+	if clsName, ok := podAnnotations[podAnnotationContainerPrefix+containerName]; ok {
+		return clsName, ClassOriginPodAnnotation
+	}
+	if clsName, ok := podAnnotations[podAnnotation]; ok {
+		return clsName, ClassOriginPodAnnotation
+	}
+	return "", ClassOriginNotFound
+}

--- a/pkg/kubernetes/annotations_test.go
+++ b/pkg/kubernetes/annotations_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+)
+
+// TestContainerClassFromAnnotations: unit test for ContainerClassFromAnnotations.
+func TestContainerClassFromAnnotations(t *testing.T) {
+	aContainerAnnotation := "io.kubernetes.cri.a-class"
+	aPodAnnotation := "a.resources.beta.kubernetes.io/pod"
+	aPodAnnotationContainerPrefix := "a.resources.beta.kubernetes.io/container."
+	bContainerAnnotation := "io.kubernetes.cri.b-class"
+	bPodAnnotation := "b.resources.beta.kubernetes.io/pod"
+	bPodAnnotationContainerPrefix := "b.resources.beta.kubernetes.io/container."
+	allContainerAnnotations := map[string]string{
+		aContainerAnnotation: "a-container-class",
+		bContainerAnnotation: "b-container-class",
+	}
+	allPodAnnotations := map[string]string{
+		aPodAnnotation: "a-pod-class",
+		aPodAnnotationContainerPrefix + "special-container": "a-pod-container-class",
+		bPodAnnotation: "b-pod-class",
+		bPodAnnotationContainerPrefix + "special-container": "b-pod-container-class",
+	}
+	tcases := []struct {
+		name string // the name of the test case
+		// inputs
+		lookForCA  string            // container annotation to look for
+		lookForPA  string            // pod annotation to look for
+		lookForPAC string            // pod annotation container prefix to look for
+		cName      string            // container name
+		cAnns      map[string]string // container annotations
+		pAnns      map[string]string // pod annotations
+		// outputs
+		expectedClass  string
+		expectedOrigin ClassOrigin
+	}{
+		{
+			name:           "all empty",
+			expectedOrigin: ClassOriginNotFound,
+		},
+		{
+			name:           "container annotation overrides all pod annotations",
+			lookForCA:      aContainerAnnotation,
+			lookForPA:      aPodAnnotation,
+			lookForPAC:     aPodAnnotationContainerPrefix,
+			cName:          "special-container",
+			cAnns:          allContainerAnnotations,
+			pAnns:          allPodAnnotations,
+			expectedClass:  "a-container-class",
+			expectedOrigin: ClassOriginContainerAnnotation,
+		},
+		{
+			name:           "container prefix overrides default pod annotation",
+			lookForCA:      "not.existing.container.annotation",
+			lookForPA:      bPodAnnotation,
+			lookForPAC:     bPodAnnotationContainerPrefix,
+			cName:          "special-container",
+			cAnns:          allContainerAnnotations,
+			pAnns:          allPodAnnotations,
+			expectedClass:  "b-pod-container-class",
+			expectedOrigin: ClassOriginPodAnnotation,
+		},
+		{
+			name:           "default pod annotation",
+			lookForCA:      "not.existing.container.annotation",
+			lookForPA:      bPodAnnotation,
+			lookForPAC:     bPodAnnotationContainerPrefix,
+			cName:          "ordinary-container",
+			cAnns:          allContainerAnnotations,
+			pAnns:          allPodAnnotations,
+			expectedClass:  "b-pod-class",
+			expectedOrigin: ClassOriginPodAnnotation,
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			observedClass, observedOrigin := ContainerClassFromAnnotations(
+				tc.lookForCA, tc.lookForPA, tc.lookForPAC,
+				tc.cName, tc.cAnns, tc.pAnns)
+			if observedClass != tc.expectedClass {
+				t.Errorf("expected class %q, observed %q", tc.expectedClass, observedClass)
+			}
+			if observedOrigin != tc.expectedOrigin {
+				t.Errorf("expected origin %q, observed %q", tc.expectedOrigin, observedOrigin)
+			}
+		})
+	}
+
+}

--- a/pkg/rdt/kubernetes.go
+++ b/pkg/rdt/kubernetes.go
@@ -18,6 +18,7 @@ package rdt
 
 import (
 	"fmt"
+	"github.com/intel/goresctrl/pkg/kubernetes"
 )
 
 const (
@@ -39,18 +40,11 @@ const (
 // container. Verifies that the class exists in goresctrl configuration and that
 // it is allowed to be used.
 func ContainerClassFromAnnotations(containerName string, containerAnnotations, podAnnotations map[string]string) (string, error) {
-	fromPodAnnotation := false
-	clsName, ok := containerAnnotations[RdtContainerAnnotation]
-	if !ok {
-		fromPodAnnotation = true
-		clsName, ok = podAnnotations[RdtPodAnnotationContainerPrefix+containerName]
+	clsName, clsOrigin := kubernetes.ContainerClassFromAnnotations(
+		RdtContainerAnnotation, RdtPodAnnotation, RdtPodAnnotationContainerPrefix,
+		containerName, containerAnnotations, podAnnotations)
 
-		if !ok {
-			clsName, ok = podAnnotations[RdtPodAnnotation]
-		}
-	}
-
-	if ok {
+	if clsOrigin != kubernetes.ClassOriginNotFound {
 		if rdt == nil {
 			return "", fmt.Errorf("RDT not initialized, class %q not available", clsName)
 		}
@@ -68,9 +62,9 @@ func ContainerClassFromAnnotations(containerName string, containerAnnotations, p
 		// If classes have been configured by goresctrl
 		if clsConf, ok := rdt.conf.Classes[unaliasClassName(clsName)]; ok {
 			// Check that the class is allowed
-			if fromPodAnnotation && clsConf.Kubernetes.DenyPodAnnotation {
+			if clsOrigin == kubernetes.ClassOriginPodAnnotation && clsConf.Kubernetes.DenyPodAnnotation {
 				return "", fmt.Errorf("RDT class %q not allowed from Pod annotations", clsName)
-			} else if !fromPodAnnotation && clsConf.Kubernetes.DenyContainerAnnotation {
+			} else if clsOrigin == kubernetes.ClassOriginContainerAnnotation && clsConf.Kubernetes.DenyContainerAnnotation {
 				return "", fmt.Errorf("RDT class %q not allowed from Container annotation", clsName)
 			}
 		}


### PR DESCRIPTION
- Add pkg/kubernetes for common annotation handling logic.
- Both blockio and rdt export their own ContainerClassFromAnnotations
  functions with the same interface.
- Refactor rdt ContainerClassFromAnnotations to use the common logic.

Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>