### PR TITLE
cgroups: fix building cgroups on darwin and freebsd

### DIFF
--- a/pkg/blockio/blockio.go
+++ b/pkg/blockio/blockio.go
@@ -435,8 +435,8 @@ func (dpm defaultPlatform) configurableBlockDevices(devWildcards []string) ([]tB
 			continue
 		}
 		sys, ok := fileInfo.Sys().(*syscall.Stat_t)
-		major := unix.Major(sys.Rdev)
-		minor := unix.Minor(sys.Rdev)
+		major := unix.Major(uint64(sys.Rdev))
+		minor := unix.Minor(uint64(sys.Rdev))
 		if !ok {
 			errors = multierror.Append(errors, fmt.Errorf("cannot get syscall stat_t from %#v: %w%s", devRealpath, err, origin))
 			continue

--- a/pkg/cgroups/cgroupid.go
+++ b/pkg/cgroups/cgroupid.go
@@ -1,13 +1,10 @@
 package cgroups
 
 import (
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
-
-	"golang.org/x/sys/unix"
 )
 
 // CgroupID implements mapping kernel cgroup IDs to cgroupfs paths with transparent caching.
@@ -23,15 +20,6 @@ func NewCgroupID(root string) *CgroupID {
 		root:  root,
 		cache: make(map[uint64]string),
 	}
-}
-
-func getID(path string) uint64 {
-	h, _, err := unix.NameToHandleAt(unix.AT_FDCWD, path, 0)
-	if err != nil {
-		return 0
-	}
-
-	return binary.LittleEndian.Uint64(h.Bytes())
 }
 
 // Find finds the path for the given cgroup id.

--- a/pkg/cgroups/cgroupid_linux.go
+++ b/pkg/cgroups/cgroupid_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+// +build linux
+
+package cgroups
+
+import (
+	"encoding/binary"
+	"golang.org/x/sys/unix"
+)
+
+func getID(path string) uint64 {
+	h, _, err := unix.NameToHandleAt(unix.AT_FDCWD, path, 0)
+	if err != nil {
+		return 0
+	}
+
+	return binary.LittleEndian.Uint64(h.Bytes())
+}

--- a/pkg/cgroups/cgroupid_other.go
+++ b/pkg/cgroups/cgroupid_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package cgroups
+
+func getID(path string) uint64 {
+	return 0
+}


### PR DESCRIPTION
Cross-platform builds of projects that use the blockio package fails
because the cgroups package uses the NameToHandleAt syscall (not
available on darwin, freebsd), and because Rdev may not be
uint64 (darwin). However the blockio package may be useful on
non-linux hosts when using OCI output. This patch fixes these build
issues and platforms.