### PR TITLE
TestRdt: consider monitor group creation failure a fatal event

### DIFF
--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -324,7 +324,7 @@ kubernetes:
 	mgAnnotations := map[string]string{"a_key": "a_value"}
 	mg, err := cls.CreateMonGroup(mgName, mgAnnotations)
 	if err != nil {
-		t.Errorf("creating mon group failed: %v", err)
+		t.Fatalf("creating mon group failed: %v", err)
 	}
 	if n := mg.Name(); n != mgName {
 		t.Errorf("MonGroup.Name() returned %q, expected %q", n, mgName)


### PR DESCRIPTION
Multiple accesses of mg follow, also group access by name,
so it will be complex to handle lack of group gracefully.