### PR TITLE
make: Enable gofmt to write changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: test
 verify: gofmt-verify ci-lint
 
 gofmt-verify:
-	@out=`gofmt -l -d $$(find . -name '*.go')`; \
+	@out=`gofmt -w -l -d $$(find . -name '*.go')`; \
 	if [ -n "$$out" ]; then \
 	    echo "$$out"; \
 	    exit 1; \


### PR DESCRIPTION
Let gofmt to write suggested changes to the files instead of
just printing them to stdout. This way we avoid any manual changes
to go files.