### PR TITLE
rdt: fix default schemata

### DIFF
--- a/pkg/rdt/config.go
+++ b/pkg/rdt/config.go
@@ -231,19 +231,21 @@ func (s catSchema) toStr(typ catSchemaType, baseSchema catSchema) (string, error
 	sep := ""
 
 	// Get a sorted slice of cache ids for deterministic output
-	ids := make([]uint64, 0, len(baseSchema.Alloc))
-	for id := range baseSchema.Alloc {
-		ids = append(ids, id)
-	}
+	ids := append([]uint64{}, info.cat[s.Lvl].cacheIds...)
 	utils.SortUint64s(ids)
 
 	minBits := info.cat[s.Lvl].minCbmBits()
 	for _, id := range ids {
-		baseMask, ok := baseSchema.Alloc[id].getEffective(typ).(catAbsoluteAllocation)
-		if !ok {
-			return "", fmt.Errorf("BUG: basemask not of type catAbsoluteAllocation")
+		// Default to 100%
+		bmask := info.cat[s.Lvl].cbmMask()
+
+		if base, ok := baseSchema.Alloc[id]; ok {
+			baseMask, ok := base.getEffective(typ).(catAbsoluteAllocation)
+			if !ok {
+				return "", fmt.Errorf("BUG: basemask not of type catAbsoluteAllocation")
+			}
+			bmask = bitmask(baseMask)
 		}
-		bmask := bitmask(baseMask)
 
 		if s.Alloc != nil {
 			var err error
@@ -416,14 +418,19 @@ func (s mbSchema) toStr(base map[uint64]uint64) string {
 	sep := ""
 
 	// Get a sorted slice of cache ids for deterministic output
-	ids := make([]uint64, 0, len(base))
-	for id := range base {
-		ids = append(ids, id)
-	}
+	ids := append([]uint64{}, info.mb.cacheIds...)
 	utils.SortUint64s(ids)
 
 	for _, id := range ids {
-		baseAllocation := base[id]
+		baseAllocation, ok := base[id]
+		if !ok {
+			if info.mb.mbpsEnabled {
+				baseAllocation = math.MaxUint32
+			} else {
+				baseAllocation = 100
+			}
+		}
+
 		value := uint64(0)
 		if info.mb.mbpsEnabled {
 			value = math.MaxUint32

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -679,6 +679,54 @@ partitions:
 		},
 		// Testcase
 		TC{
+			name: "Default L3 CAT",
+			fs:   "resctrl.full",
+			config: `
+options:
+partitions:
+  part-1:
+    mbAllocation: [100%]
+    classes:
+      class-1:
+        mbAllocation: [50%]
+`,
+			schemata: map[string]Schemata{
+				"class-1": Schemata{
+					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
+					mb: "0=50;1=50;2=50;3=50",
+				},
+				"system/default": Schemata{
+					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
+					mb: "0=100;1=100;2=100;3=100",
+				},
+			},
+		},
+		// Testcase
+		TC{
+			name: "Default MBA",
+			fs:   "resctrl.full",
+			config: `
+options:
+partitions:
+  part-1:
+    l3Allocation: 100%
+    classes:
+      class-1:
+        l3Allocation: 50%
+`,
+			schemata: map[string]Schemata{
+				"class-1": Schemata{
+					l3: "0=3ff;1=3ff;2=3ff;3=3ff",
+					mb: "0=100;1=100;2=100;3=100",
+				},
+				"system/default": Schemata{
+					l3: "0=fffff;1=fffff;2=fffff;3=fffff",
+					mb: "0=100;1=100;2=100;3=100",
+				},
+			},
+		},
+		// Testcase
+		TC{
 			name:        "duplicate class names (fail)",
 			fs:          "resctrl.nomb",
 			configErrRe: `"class-1" defined multiple times`,


### PR DESCRIPTION
Fix a bug attempting to write an incorrect (empty) schemata to resctrl
when config of the corresponding control (CAT or MBA) is not specified.
In more detail, an incorrect schemata was generated if CAT was enabled
in the system but no l2/l3allocation was specified in the config (or
similarly MBA was enabled but no mbAllocation was specified in the
config). This patch fixes the error, allocating "100%" (all cache lines
or full memory bandwidth) if nothing is specified in the config. This
aligns with the system default when creating new resctrl groups.