### PR TITLE
utils: add functions for setting uncore frequency limits

### DIFF
--- a/pkg/utils/sysfs.go
+++ b/pkg/utils/sysfs.go
@@ -19,18 +19,18 @@ package utils
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
 
+const (
+	SysfsUncoreBasepath = "/sys/devices/system/cpu/intel_uncore_frequency/"
+)
+
 func setCPUFreqValue(cpu ID, setting string, value int) error {
-	str := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/%s", cpu, setting)
-
-	if err := ioutil.WriteFile(str, []byte(strconv.Itoa(value)), 0644); err != nil {
-		return err
-	}
-
-	return nil
+	path := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/%s", cpu, setting)
+	return writeFileInt(path, value)
 }
 
 // GetCPUFreqValue returns information of the currently used CPU frequency
@@ -80,4 +80,57 @@ func SetCPUsScalingMaxFreq(cpus []ID, freq int) error {
 	}
 
 	return nil
+}
+
+// UncoreFreqAvailable returns true if the uncore frequency control functions are available.
+func UncoreFreqAvailable() bool {
+	_, err := os.Stat(SysfsUncoreBasepath)
+	return err == nil
+}
+
+// SetUncoreMinFreq sets the minimum uncore frequency of a CPU die. Frequency is specified in kHz.
+func SetUncoreMinFreq(pkg, die ID, freqKhz int) error {
+	return setUncoreFreqValue(pkg, die, "min_freq_khz", freqKhz)
+}
+
+// SetUncoreMaxFreq sets the maximum uncore frequency of a CPU die. Frequency is specified in kHz.
+func SetUncoreMaxFreq(pkg, die ID, freqKhz int) error {
+	return setUncoreFreqValue(pkg, die, "max_freq_khz", freqKhz)
+}
+
+func uncoreFreqPath(pkg, die ID, attribute string) string {
+	return fmt.Sprintf(SysfsUncoreBasepath+"package_%02d_die_%02d/%s", pkg, die, attribute)
+}
+
+func getUncoreFreqValue(pkg, die ID, attribute string) (int, error) {
+	return readFileInt(uncoreFreqPath(pkg, die, attribute))
+}
+
+func setUncoreFreqValue(pkg, die ID, attribute string, value int) error {
+	// Bounds checking
+	if hwMinFreq, err := getUncoreFreqValue(pkg, die, "initial_min_freq_khz"); err != nil {
+		return err
+	} else if value < hwMinFreq {
+		value = hwMinFreq
+	}
+	if hwMaxFreq, err := getUncoreFreqValue(pkg, die, "initial_max_freq_khz"); err != nil {
+		return err
+	} else if value > hwMaxFreq {
+		value = hwMaxFreq
+	}
+
+	return writeFileInt(uncoreFreqPath(pkg, die, attribute), value)
+}
+
+func writeFileInt(path string, value int) error {
+	return ioutil.WriteFile(path, []byte(strconv.Itoa(value)), 0644)
+}
+
+func readFileInt(path string) (int, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	i, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 32)
+	return int(i), err
 }


### PR DESCRIPTION
Relies on the intel_uncore_frequency kernel driver that exposes ucore
frequency settings via sysfs and is available since Linux v5.6.