### PR TITLE
remove check minor must be 0

### DIFF
--- a/pkg/blockio/blockio.go
+++ b/pkg/blockio/blockio.go
@@ -441,10 +441,6 @@ func (dpm defaultPlatform) configurableBlockDevices(devWildcards []string) ([]tB
 			errors = multierror.Append(errors, fmt.Errorf("cannot get syscall stat_t from %#v: %w%s", devRealpath, err, origin))
 			continue
 		}
-		if minor&0xf != 0 {
-			errors = multierror.Append(errors, fmt.Errorf("skipping %#v: cannot weight/throttle partitions%s", devRealpath, origin))
-			continue
-		}
 		blockDevices = append(blockDevices, tBlockDeviceInfo{
 			Major:   int64(major),
 			Minor:   int64(minor),

--- a/pkg/blockio/blockio_test.go
+++ b/pkg/blockio/blockio_test.go
@@ -163,15 +163,7 @@ func TestConfigurableBlockDevices(t *testing.T) {
 			devBlockDevs = append(devBlockDevs, strings.Replace(sysfsBlockDev, "/sys/block/", "/dev/", 1))
 		}
 	}
-	devPartitions := []string{}
-	for _, devBlockDev := range devBlockDevs {
-		devPartitions, _ = filepath.Glob(devBlockDev + "[0-9]")
-		if len(devPartitions) > 0 {
-			break
-		}
-	}
 	t.Logf("test real block devices: %v", devBlockDevs)
-	t.Logf("test partitions: %v", devPartitions)
 	tcases := []struct {
 		name                    string
 		devWildcards            []string
@@ -214,14 +206,6 @@ func TestConfigurableBlockDevices(t *testing.T) {
 			name:            "real block devices",
 			devWildcards:    devBlockDevs,
 			expectedMatches: len(devBlockDevs),
-		},
-		{
-			name:                    "partition",
-			devWildcards:            devPartitions,
-			expectedErrorCount:      len(devPartitions),
-			expectedErrorSubstrings: []string{"cannot weight/throttle partitions"},
-			disabled:                len(devPartitions) == 0,
-			disabledReason:          "no block device partitions found",
 		},
 	}
 	for _, tc := range tcases {


### PR DESCRIPTION
minor can be [any number](https://www.kernel.org/doc/Documentation/admin-guide/devices.txt), not necessarily 0.

example:
```
8 block	SCSI disk devices (0-15)
		  0 = /dev/sda		First SCSI disk whole disk
		 16 = /dev/sdb		Second SCSI disk whole disk
		 32 = /dev/sdc		Third SCSI disk whole disk
		    ...
		240 = /dev/sdp		Sixteenth SCSI disk whole disk

9 block	Metadisk (RAID) devices
		  0 = /dev/md0		First metadisk group
		  1 = /dev/md1		Second metadisk group
```