### PR TITLE
Support configurable mount prefix

### DIFF
--- a/cmd/sst-ctl/main.go
+++ b/cmd/sst-ctl/main.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	goresctrlpath "github.com/intel/goresctrl/pkg/path"
 	"github.com/intel/goresctrl/pkg/sst"
 	"github.com/intel/goresctrl/pkg/utils"
 )
@@ -69,6 +70,10 @@ func main() {
 
 func addGlobalFlags(flagset *flag.FlagSet) {
 	flagset.StringVar(&packageIds, "package", "", "One or more physical package id")
+	flagset.Func("prefix", "set mount prefix for system directories", func(s string) error {
+		goresctrlpath.SetPrefix(s)
+		return nil
+	})
 }
 
 func printPackageInfo(pkgId ...int) error {

--- a/pkg/blockio/blockio.go
+++ b/pkg/blockio/blockio.go
@@ -119,6 +119,7 @@ import (
 
 	"github.com/intel/goresctrl/pkg/cgroups"
 	grclog "github.com/intel/goresctrl/pkg/log"
+	goresctrlpath "github.com/intel/goresctrl/pkg/path"
 )
 
 const (
@@ -240,9 +241,10 @@ func SetCgroupClass(group string, class string) error {
 // Returns schedulers in a map: {"/dev/sda": "bfq"}
 func getCurrentIOSchedulers() (map[string]string, error) {
 	var ios = map[string]string{}
-	schedulerFiles, err := filepath.Glob(sysfsBlockDeviceIOSchedulerPaths)
+	glob := goresctrlpath.Path(sysfsBlockDeviceIOSchedulerPaths)
+	schedulerFiles, err := filepath.Glob(glob)
 	if err != nil {
-		return ios, fmt.Errorf("error in I/O scheduler wildcards %#v: %w", sysfsBlockDeviceIOSchedulerPaths, err)
+		return ios, fmt.Errorf("error in I/O scheduler wildcards %#v: %w", glob, err)
 	}
 	for _, schedulerFile := range schedulerFiles {
 		devName := strings.SplitN(schedulerFile, "/", 5)[3]

--- a/pkg/cgroups/cgroupblkio_test.go
+++ b/pkg/cgroups/cgroupblkio_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/intel/goresctrl/pkg/testutils"
 )
 
+var mountDir = "/sys/fs/cgroup"
+
 func TestUpdateAppend(t *testing.T) {
 	tcases := []struct {
 		name                    string

--- a/pkg/cgroups/cgroupcontrol.go
+++ b/pkg/cgroups/cgroupcontrol.go
@@ -105,7 +105,7 @@ func (c Controller) String() string {
 
 // Path returns the absolute path of the given controller.
 func (c Controller) Path() string {
-	return path.Join(mountDir, c.String())
+	return cgroupPath(c.String())
 }
 
 // RelPath returns the relative path of the given controller.
@@ -115,7 +115,7 @@ func (c Controller) RelPath() string {
 
 // Group returns the given group for the controller.
 func (c Controller) Group(group string) Group {
-	return Group(path.Join(mountDir, c.String(), group))
+	return Group(cgroupPath(c.String(), group))
 }
 
 // AsGroup returns the group for the given absolute directory path.
@@ -125,7 +125,7 @@ func AsGroup(absDir string) Group {
 
 // Controller returns the controller for the group.
 func (g Group) Controller() Controller {
-	relPath := strings.TrimPrefix(string(g), mountDir+"/")
+	relPath := strings.TrimPrefix(string(g), cgroupPath()+"/")
 	split := strings.SplitN(relPath, "/", 2)
 	if len(split) > 0 {
 		return controllerDirs[split[0]]
@@ -232,6 +232,6 @@ func (g Group) writePids(entry string, pids ...string) error {
 
 // error returns a formatted group-specific error.
 func (g Group) errorf(format string, args ...interface{}) error {
-	name := strings.TrimPrefix(string(g), mountDir+"/")
+	name := strings.TrimPrefix(string(g), cgroupPath()+"/")
 	return fmt.Errorf("cgroup "+name+": "+format, args...)
 }

--- a/pkg/cgroups/cgrouppath.go
+++ b/pkg/cgroups/cgrouppath.go
@@ -15,8 +15,7 @@
 package cgroups
 
 import (
-	"path"
-	"path/filepath"
+	goresctrlpath "github.com/intel/goresctrl/pkg/path"
 )
 
 // nolint
@@ -37,39 +36,18 @@ const (
 	CpusetMems = "cpuset.mems"
 )
 
-var (
-	// mount is the parent directory for per-controller cgroupfs mounts.
-	mountDir = "/sys/fs/cgroup"
-	// v2Dir is the parent directory for per-controller cgroupfs mounts.
-	v2Dir = path.Join(mountDir, "unified")
-	// KubeletRoot is the --cgroup-root option the kubelet is running with.
-	KubeletRoot = ""
-)
+const cgroupBasePath = "sys/fs/cgroup"
 
 // GetMountDir returns the common mount point for cgroup v1 controllers.
 func GetMountDir() string {
-	return mountDir
-}
-
-// SetMountDir sets the common mount point for the cgroup v1 controllers.
-func SetMountDir(dir string) {
-	v2, _ := filepath.Rel(mountDir, v2Dir)
-	mountDir = dir
-	if v2 != "" {
-		v2Dir = path.Join(mountDir, v2)
-	}
+	return cgroupPath()
 }
 
 // GetV2Dir returns the cgroup v2 unified mount directory.
 func GetV2Dir() string {
-	return v2Dir
+	return cgroupPath("unified")
 }
 
-// SetV2Dir sets the unified cgroup v2 mount directory.
-func SetV2Dir(dir string) {
-	if dir[0] == '/' {
-		v2Dir = dir
-	} else {
-		v2Dir = path.Join(mountDir, v2Dir)
-	}
+func cgroupPath(elems ...string) string {
+	return goresctrlpath.Path(append([]string{cgroupBasePath}, elems...)...)
 }

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import "path/filepath"
+
+// RootDir is a helper for handling system directory paths
+type RootDir string
+
+var prefix RootDir = "/"
+
+// Path returns a full path to a file under RootDir
+func (d RootDir) Path(elems ...string) string {
+	return filepath.Join(append([]string{string(d)}, elems...)...)
+}
+
+// SetPrefix sets the global path prefix to use for all system files.
+func SetPrefix(p string) { prefix = RootDir(p) }
+
+// Path returns a path to a file, prefixed with the global prefix.
+func Path(elems ...string) string { return prefix.Path(elems...) }

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	// Helper function for checking test cases
+	TC := func(path []string, expected string) {
+		if result := Path(path...); result != expected {
+			t.Errorf("unexpected path: %v -> %q, expected %q", path, result, expected)
+		}
+	}
+
+	// Run test cases
+	TC([]string{}, "/")
+	TC([]string{"foo"}, "/foo")
+
+	SetPrefix("/prefix/mnt/")
+	TC([]string{}, "/prefix/mnt")
+	TC([]string{"/foo", "bar"}, "/prefix/mnt/foo/bar")
+}

--- a/pkg/sst/sst.go
+++ b/pkg/sst/sst.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	grclog "github.com/intel/goresctrl/pkg/log"
+	goresctrlpath "github.com/intel/goresctrl/pkg/path"
 	"github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -75,18 +76,19 @@ const (
 // ClosCPUSet contains mapping from Clos id to a set of CPU ids
 type ClosCPUSet map[int]utils.IDSet
 
-const isstDevPath = "/dev/isst_interface"
-
 var sstlog grclog.Logger = grclog.NewLoggerWrapper(stdlog.New(os.Stderr, "[ sst ] ", 0))
+
+func isstDevPath() string { return goresctrlpath.Path("dev/isst_interface") }
 
 // SstSupported returns true if Intel Speed Select Technologies (SST) is supported
 // by the system and can be interfaced via the Linux kernel device
 func SstSupported() bool {
-	if _, err := os.Stat(isstDevPath); err != nil {
+	devPath := isstDevPath()
+	if _, err := os.Stat(devPath); err != nil {
 		if !os.IsNotExist(err) {
-			sstlog.Warnf("failed to access sst device %q: %v", isstDevPath, err)
+			sstlog.Warnf("failed to access sst device %q: %v", devPath, err)
 		} else {
-			sstlog.Debugf("sst device %q does not exist", isstDevPath)
+			sstlog.Debugf("sst device %q does not exist", devPath)
 		}
 		return false
 	}

--- a/pkg/sst/sst_if.go
+++ b/pkg/sst/sst_if.go
@@ -45,9 +45,10 @@ func punitCPU(cpu utils.ID) (utils.ID, error) {
 
 // isstIoctl is a helper for executing ioctls on the linux isst_if device driver
 func isstIoctl(ioctl uintptr, req uintptr) error {
-	f, err := os.Open(isstDevPath)
+	devPath := isstDevPath()
+	f, err := os.Open(devPath)
 	if err != nil {
-		return fmt.Errorf("failed to open isst device %q: %v", isstDevPath, err)
+		return fmt.Errorf("failed to open isst device %q: %v", devPath, err)
 	}
 	defer f.Close()
 

--- a/pkg/sst/sysfs.go
+++ b/pkg/sst/sysfs.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	goresctrlpath "github.com/intel/goresctrl/pkg/path"
 	"github.com/intel/goresctrl/pkg/utils"
 )
 
@@ -36,7 +37,7 @@ func (pkg *cpuPackageInfo) hasCpus(cpus utils.IDSet) bool {
 }
 
 func getOnlineCpuPackages() (map[int]*cpuPackageInfo, error) {
-	basePath := "/sys/bus/cpu/devices"
+	basePath := goresctrlpath.Path("sys/bus/cpu/devices")
 
 	files, err := ioutil.ReadDir(basePath)
 	if err != nil {

--- a/pkg/utils/msr.go
+++ b/pkg/utils/msr.go
@@ -20,12 +20,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+
+	goresctrlpath "github.com/intel/goresctrl/pkg/path"
 )
 
 func ReadMSR(cpu ID, msr int64) (uint64, error) {
-	str := fmt.Sprintf("/dev/cpu/%d/msr", cpu)
-
-	file, err := os.Open(str)
+	path := goresctrlpath.Path("dev/cpu", fmt.Sprintf("%d", cpu), "msr")
+	file, err := os.Open(path)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/utils/sysfs.go
+++ b/pkg/utils/sysfs.go
@@ -22,22 +22,22 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	goresctrlpath "github.com/intel/goresctrl/pkg/path"
 )
 
 const (
-	SysfsUncoreBasepath = "/sys/devices/system/cpu/intel_uncore_frequency/"
+	SysfsUncoreBasepath = "sys/devices/system/cpu/intel_uncore_frequency"
+	SysfsCpuBasepath    = "sys/devices/system/cpu"
 )
 
 func setCPUFreqValue(cpu ID, setting string, value int) error {
-	path := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/%s", cpu, setting)
-	return writeFileInt(path, value)
+	return writeFileInt(cpuFreqPath(cpu, setting), value)
 }
 
 // GetCPUFreqValue returns information of the currently used CPU frequency
 func GetCPUFreqValue(cpu ID, setting string) (int, error) {
-	str := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/%s", cpu, setting)
-
-	raw, err := ioutil.ReadFile(str)
+	raw, err := ioutil.ReadFile(cpuFreqPath(cpu, setting))
 	if err != nil {
 		return 0, err
 	}
@@ -48,6 +48,10 @@ func GetCPUFreqValue(cpu ID, setting string) (int, error) {
 	}
 
 	return value, nil
+}
+
+func cpuFreqPath(cpu ID, setting string) string {
+	return goresctrlpath.Path(SysfsCpuBasepath, fmt.Sprintf("cpu%d", cpu), "cpufreq", setting)
 }
 
 // SetCPUScalingMinFreq sets the scaling_min_freq value of a given CPU
@@ -84,7 +88,7 @@ func SetCPUsScalingMaxFreq(cpus []ID, freq int) error {
 
 // UncoreFreqAvailable returns true if the uncore frequency control functions are available.
 func UncoreFreqAvailable() bool {
-	_, err := os.Stat(SysfsUncoreBasepath)
+	_, err := os.Stat(goresctrlpath.Path(SysfsUncoreBasepath))
 	return err == nil
 }
 
@@ -99,7 +103,7 @@ func SetUncoreMaxFreq(pkg, die ID, freqKhz int) error {
 }
 
 func uncoreFreqPath(pkg, die ID, attribute string) string {
-	return fmt.Sprintf(SysfsUncoreBasepath+"package_%02d_die_%02d/%s", pkg, die, attribute)
+	return goresctrlpath.Path(SysfsUncoreBasepath, fmt.Sprintf("package_%02d_die_%02d", pkg, die), attribute)
 }
 
 func getUncoreFreqValue(pkg, die ID, attribute string) (int, error) {


### PR DESCRIPTION
Split into multiple separate patches:

- Add confugurable system prefix
  Add new "github.com/intel/goresctrl/pkg/path" package for specifying
global prefix for system directories. This is supposed to be taken into
use by all separate components (cgroup, sysfs. rdt).
- cgroup: add support mount prefix
- sst: add support for specifying mount prefix
- blockio: support mount prefix
  The blockio package will follow the global mount prefix specified with
using SetPrefix() from "github.com/intel/goresctrl/pkg/path".
- pkg/utils: support mount prefix
  Make the functionality in the utils  package will follow the global
mount prefix specified with using SetPrefix() from
"github.com/intel/goresctrl/pkg/path".