### PR TITLE
Stop using io/ioutil package

### DIFF
--- a/pkg/blockio/blockio.go
+++ b/pkg/blockio/blockio.go
@@ -102,7 +102,6 @@ package blockio
 
 import (
 	"fmt"
-	"io/ioutil"
 	stdlog "log"
 	"os"
 	"path/filepath"
@@ -162,7 +161,7 @@ func SetLogger(l grclog.Logger) {
 // SetConfigFromFile reads and applies blockio configuration from the
 // filesystem.
 func SetConfigFromFile(filename string, force bool) error {
-	if data, err := ioutil.ReadFile(filename); err == nil {
+	if data, err := os.ReadFile(filename); err == nil {
 		if err = SetConfigFromData(data, force); err != nil {
 			return fmt.Errorf("failed to set configuration from file %q: %s", filename, err)
 		}
@@ -248,7 +247,7 @@ func getCurrentIOSchedulers() (map[string]string, error) {
 	}
 	for _, schedulerFile := range schedulerFiles {
 		devName := strings.SplitN(schedulerFile, "/", 5)[3]
-		schedulerDataB, err := ioutil.ReadFile(schedulerFile)
+		schedulerDataB, err := os.ReadFile(schedulerFile)
 		if err != nil {
 			// A block device may be disconnected.
 			log.Errorf("failed to read current I/O scheduler %#v: %v\n", schedulerFile, err)

--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -19,7 +19,6 @@ package rdt
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -336,6 +335,6 @@ func readFileBitmask(path string) (bitmask, error) {
 }
 
 func readFileString(path string) (string, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	return strings.TrimSpace(string(data)), err
 }

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -47,7 +47,6 @@ package rdt
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	stdlog "log"
 	"os"
 	"path/filepath"
@@ -245,7 +244,7 @@ func SetConfigFromData(data []byte, force bool) error {
 // SetConfigFromFile reads configuration from the filesystem and reconfigures
 // the resctrl filesystem.
 func SetConfigFromFile(path string, force bool) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read config file: %v", err)
 	}
@@ -491,11 +490,11 @@ func (c *control) pruneMonGroups() error {
 }
 
 func (c *control) readRdtFile(rdtPath string) ([]byte, error) {
-	return ioutil.ReadFile(filepath.Join(info.resctrlPath, rdtPath))
+	return os.ReadFile(filepath.Join(info.resctrlPath, rdtPath))
 }
 
 func (c *control) writeRdtFile(rdtPath string, data []byte) error {
-	if err := ioutil.WriteFile(filepath.Join(info.resctrlPath, rdtPath), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(info.resctrlPath, rdtPath), data, 0644); err != nil {
 		return c.cmdError(err)
 	}
 	return nil
@@ -729,7 +728,7 @@ func (r *resctrlGroup) GetMonData() MonData {
 }
 
 func (r *resctrlGroup) getMonL3Data() (MonL3Data, error) {
-	files, err := ioutil.ReadDir(r.path("mon_data"))
+	files, err := os.ReadDir(r.path("mon_data"))
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +759,7 @@ func (r *resctrlGroup) getMonL3Data() (MonL3Data, error) {
 }
 
 func (r *resctrlGroup) getMonLeafData(path string) (MonLeafData, error) {
-	files, err := ioutil.ReadDir(r.path(path))
+	files, err := os.ReadDir(r.path(path))
 	if err != nil {
 		return nil, err
 	}
@@ -827,7 +826,7 @@ func (m *monGroup) GetAnnotations() map[string]string {
 }
 
 func resctrlGroupsFromFs(prefix string, path string) ([]string, error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rdt
 
 import (
-	"io/ioutil"
 	stdlog "log"
 	"os"
 	"os/exec"
@@ -51,7 +50,7 @@ func newMockResctrlFs(t *testing.T, name, mountOpts string) (*mockResctrlFs, err
 	m := &mockResctrlFs{t: t}
 
 	m.origDir = testdata.Path(name)
-	m.baseDir, err = ioutil.TempDir("", "goresctrl.test.")
+	m.baseDir, err = os.MkdirTemp("", "goresctrl.test.")
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +62,7 @@ func newMockResctrlFs(t *testing.T, name, mountOpts string) (*mockResctrlFs, err
 	mountInfoPath = filepath.Join(m.baseDir, "mounts")
 	resctrlPath := filepath.Join(m.baseDir, "resctrl")
 	data := "resctrl " + resctrlPath + " resctrl " + mountOpts + " 0 0\n"
-	if err := ioutil.WriteFile(mountInfoPath, []byte(data), 0644); err != nil {
+	if err := os.WriteFile(mountInfoPath, []byte(data), 0644); err != nil {
 		m.delete()
 		return nil, err
 	}
@@ -100,7 +99,7 @@ func (m *mockResctrlFs) verifyTextFile(relPath, content string) {
 }
 
 func verifyTextFile(t *testing.T, path, content string) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed to read %q: %v", path, err)
 	}
@@ -283,7 +282,7 @@ kubernetes:
 
 	// Verify that existing goresctrl monitor groups were removed
 	for _, cls := range []string{RootClassName, "Guaranteed"} {
-		files, _ := ioutil.ReadDir(rdt.classes[cls].path("mon_groups"))
+		files, _ := os.ReadDir(rdt.classes[cls].path("mon_groups"))
 		for _, f := range files {
 			if strings.HasPrefix(mockGroupPrefix, f.Name()) {
 				t.Errorf("unexpected monitor group found %q", f.Name())

--- a/pkg/sst/sysfs.go
+++ b/pkg/sst/sysfs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sst
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -39,7 +38,7 @@ func (pkg *cpuPackageInfo) hasCpus(cpus utils.IDSet) bool {
 func getOnlineCpuPackages() (map[int]*cpuPackageInfo, error) {
 	basePath := goresctrlpath.Path("sys/bus/cpu/devices")
 
-	files, err := ioutil.ReadDir(basePath)
+	files, err := os.ReadDir(basePath)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +47,7 @@ func getOnlineCpuPackages() (map[int]*cpuPackageInfo, error) {
 
 	for _, file := range files {
 		// Try to read siblings from topology
-		raw, err := ioutil.ReadFile(filepath.Join(basePath, file.Name(), "topology/physical_package_id"))
+		raw, err := os.ReadFile(filepath.Join(basePath, file.Name(), "topology/physical_package_id"))
 		if os.IsNotExist(err) {
 			// Offline -> topology information does not exist
 			continue

--- a/pkg/testutils/file.go
+++ b/pkg/testutils/file.go
@@ -15,12 +15,12 @@
 package testutils
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func CreateTempFile(t *testing.T, data string) string {
-	f, err := ioutil.TempFile("", "goresctrl-testutils-")
+	f, err := os.CreateTemp("", "goresctrl-testutils-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/utils/sysfs.go
+++ b/pkg/utils/sysfs.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +36,7 @@ func setCPUFreqValue(cpu ID, setting string, value int) error {
 
 // GetCPUFreqValue returns information of the currently used CPU frequency
 func GetCPUFreqValue(cpu ID, setting string) (int, error) {
-	raw, err := ioutil.ReadFile(cpuFreqPath(cpu, setting))
+	raw, err := os.ReadFile(cpuFreqPath(cpu, setting))
 	if err != nil {
 		return 0, err
 	}
@@ -127,11 +126,11 @@ func setUncoreFreqValue(pkg, die ID, attribute string, value int) error {
 }
 
 func writeFileInt(path string, value int) error {
-	return ioutil.WriteFile(path, []byte(strconv.Itoa(value)), 0644)
+	return os.WriteFile(path, []byte(strconv.Itoa(value)), 0644)
 }
 
 func readFileInt(path string) (int, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
As of Go v1.17 all of the functionality has been available in the "os" package. The "io/ioutil" is deprecated starting from Go v1.19.