### PR TITLE
sst: fixes to BF error handling

### DIFF
--- a/pkg/sst/sst.go
+++ b/pkg/sst/sst.go
@@ -359,7 +359,9 @@ func enableBF(info *SstPackageInfo) error {
 
 // EnableBF enables SST-BF and sets it up properly
 func EnableBF(pkgs ...int) error {
-	if !isHWPEnabled() {
+	if ok, err := isHWPEnabled(); err != nil {
+		return fmt.Errorf("Failed to determine if HWP is enabled")
+	} else if !ok {
 		return fmt.Errorf("HWP is not enabled")
 	}
 

--- a/pkg/sst/sst.go
+++ b/pkg/sst/sst.go
@@ -371,11 +371,8 @@ func EnableBF(pkgs ...int) error {
 	}
 
 	for _, i := range info {
-		err = enableBF(i)
-		if err != nil {
-			// Ignore but log error as there might be packages in the
-			// user supplied list that do not exists
-			sstlog.Errorf("sst-bf : %w", err)
+		if err := enableBF(i); err != nil {
+			return err
 		}
 	}
 
@@ -417,11 +414,8 @@ func DisableBF(pkgs ...int) error {
 	}
 
 	for _, i := range info {
-		err = disableBF(i)
-		if err != nil {
-			// Ignore but log error as there might be packages in the
-			// user supplied list that do not exists
-			sstlog.Errorf("sst-bf : %w", err)
+		if err := disableBF(i); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/sst/sysfs.go
+++ b/pkg/sst/sysfs.go
@@ -74,13 +74,13 @@ func getOnlineCpuPackages() (map[int]*cpuPackageInfo, error) {
 	return pkgs, nil
 }
 
-func isHWPEnabled() bool {
+func isHWPEnabled() (bool, error) {
 	status, err := utils.ReadMSR(0, MSR_PM_ENABLE)
 	if err != nil {
-		return false
+		return false, err
 	}
 
-	return (status & 0xff) != 0
+	return (status & 0xff) != 0, nil
 }
 
 func setCPUScalingMin2CPUInfoMinFreq(cpu utils.ID) error {


### PR DESCRIPTION
- separate error if HWP status cannot be determined
  Don't return a misleading error that "HWP is not enabled" if we are not actually able to determine whether it's enabled or not.
- don't mask errors on BF enable