### PR TITLE
Improve github workflows

### DIFF
--- a/.github/workflows/common-codeql.yaml
+++ b/.github/workflows/common-codeql.yaml
@@ -1,0 +1,19 @@
+name: CodeQL
+on:
+  workflow_call:
+
+jobs:
+  codeql-scan:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: go
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/common-trivy.yaml
+++ b/.github/workflows/common-trivy.yaml
@@ -1,0 +1,89 @@
+name: Trivy
+on:
+  workflow_call:
+    inputs:
+      upload-to-github-security-tab:
+        default: false
+        required: false
+        type: boolean
+      export-csv:
+        default: false
+        required: false
+        type: boolean
+jobs:
+  trivy-scan-licenses:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run Trivy in fs mode
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: fs
+        scan-ref: .
+        exit-code: 1
+        scanners: license
+        severity: "UNKNOWN,MEDIUM,HIGH,CRITICAL"
+
+  trivy-scan-vulns:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run Trivy in fs mode
+      continue-on-error: true
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: fs
+        scan-ref: .
+        exit-code: 1
+        list-all-pkgs: true
+        format: json
+        output: trivy-report.json
+
+    - name: Show report in human-readable format
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: convert
+        vuln-type: ''
+        severity: ''
+        image-ref: trivy-report.json
+        format: table
+
+    - name: Convert report to sarif format
+      if: ${{ inputs.upload-to-github-security-tab }}
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: convert
+        vuln-type: ''
+        severity: ''
+        image-ref: trivy-report.json
+        format: sarif
+        output: trivy-report.sarif
+
+    - name: Upload sarif report to GitHub Security tab
+      if: ${{ inputs.upload-to-github-security-tab }}
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+       sarif_file: trivy-report.sarif
+
+    - name: Convert report to csv
+      if: ${{ inputs.export-csv }}
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: convert
+        vuln-type: ''
+        severity: ''
+        image-ref: trivy-report.json
+        format: template
+        template: "@.github/workflows/trivy-csv.tpl"
+        output: trivy-report.csv
+
+    - name: Upload CSV report as an artifact
+      if: ${{ inputs.export-csv }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: trivy-report
+        path: trivy-report.csv

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,15 @@
+name: Release
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  trivy:
+    uses: "./.github/workflows/common-trivy.yaml"
+    with:
+      export-csv: true

--- a/.github/workflows/trivy-csv.tpl
+++ b/.github/workflows/trivy-csv.tpl
@@ -1,0 +1,29 @@
+{{ range . }}
+Trivy Vulnerability Scan Results ({{- .Target -}})
+VulnerabilityID,Severity,CVSS Score,Title,Library,Vulnerable Version,Fixed Version,Information URL,Triage Information
+{{ range .Vulnerabilities }}
+    {{- .VulnerabilityID }},
+    {{- .Severity }},
+    {{- range $key, $value := .CVSS }}
+        {{- if (eq $key "nvd") }}
+            {{- .V3Score -}}
+        {{- end }}
+    {{- end }},
+    {{- quote .Title }},
+    {{- quote .PkgName }},
+    {{- quote .InstalledVersion }},
+    {{- quote .FixedVersion }},
+    {{- .PrimaryURL }}
+{{ else -}}
+    No vulnerabilities found at this time.
+{{ end }}
+Trivy Dependency Scan Results ({{ .Target }})
+ID,Name,Version,Notes
+{{ range .Packages -}}
+    {{- quote .ID }},
+    {{- quote .Name }},
+    {{- quote .Version }}
+{{ else -}}
+    No dependencies found at this time.
+{{ end }}
+{{ end }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -33,3 +33,6 @@ jobs:
     uses: "./.github/workflows/common-trivy.yaml"
     with:
       upload-to-github-security-tab: true
+
+  codeql:
+    uses: "./.github/workflows/common-codeql.yaml"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,5 +1,7 @@
 name: Verify
 on:
+  schedule:
+    - cron: '15 3 * * *'
   pull_request:
     paths-ignore:
       - "**.md"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -28,3 +28,8 @@ jobs:
 
     - name: Codecov report
       run: bash <(curl -s https://codecov.io/bash)
+
+  trivy:
+    uses: "./.github/workflows/common-trivy.yaml"
+    with:
+      upload-to-github-security-tab: true

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,17 +1,20 @@
 name: Verify
-on: [push, pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
-
-  build:
-    name: Build
+  test-and-lint:
     runs-on: ubuntu-22.04
     steps:
-
     - uses: actions/checkout@v2
 
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.20"
+        go-version-file: go.mod
 
     - name: Install golangci-lint
       run: |


### PR DESCRIPTION
This PR contains multiple enhancements to github workflows.

- split verify in common and per-pr part
  This patch specifies concurrency so that earlier jobs on the same PR get
  cancelled (if PR is updated in quick succession). Also, it changes the
  workflow to take the Go version from the go.mod file, making future
  maintenance easier as there is no more need to edit the github workflow
  file when bumping Go version.
- github workflows: add trivy scanning
  Enable Trivy scanning for licenses and vulnerabilities. This is now
  hooked in to the PR verification workflow but it has a common part for
  integrating it with other workflows (release, periodic scanning) and
  uploading reports as build artefacts.
- github workflows: enable CodeQL analysis
- github workflows: add periodic verify workflow
  Add a workflow to run the verify jobs nightly.
- github workflows: add release workflow
  Add a separate workflow to run when releases are published. Currently
  there is only one job for running Trivy scanning and storing the report
  as a build artefact.

All the workflows have been verified in my personal repo:
https://github.com/marquiz/goresctrl/actions