### PR TITLE
Use strict yaml/json unmarshal for config files

### DIFF
--- a/pkg/blockio/blockio.go
+++ b/pkg/blockio/blockio.go
@@ -173,7 +173,7 @@ func SetConfigFromFile(filename string, force bool) error {
 // SetConfigFromData parses and applies configuration from data.
 func SetConfigFromData(data []byte, force bool) error {
 	config := &Config{}
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	if err := yaml.UnmarshalStrict(data, &config); err != nil {
 		return err
 	}
 	return SetConfig(config, force)

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -234,7 +234,7 @@ func SetConfig(c *Config, force bool) error {
 // reconfigures the resctrl filesystem.
 func SetConfigFromData(data []byte, force bool) error {
 	cfg := &Config{}
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.UnmarshalStrict(data, cfg); err != nil {
 		return fmt.Errorf("failed to parse configuration data: %v", err)
 	}
 


### PR DESCRIPTION
Config file will fail if uknown fields are encountered. Mitigates configuration mistakes e.g. because of typos.

> **NOTE:** this will be a breaking change for existing users having unknown fields in the configuration file