### PR TITLE
github: add new scan-periodic workflow

### DIFF
--- a/.github/workflows/scan-periodic.yaml
+++ b/.github/workflows/scan-periodic.yaml
@@ -1,0 +1,16 @@
+name: Scan periodic
+on:
+  schedule:
+    - cron: '15 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    permissions:
+      contents: read
+      security-events: write
+    uses: "./.github/workflows/common-trivy.yaml"
+    with:
+      upload-to-github-security-tab: true

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,7 +1,6 @@
 name: Verify
 on:
-  schedule:
-    - cron: '15 3 * * *'
+  push:
   pull_request:
     paths-ignore:
       - "**.md"


### PR DESCRIPTION
Only do trivy scanning in the periodic worflow as other results do not change without changing something in the repository.

Also add "on.push" trigger to the verify workflow so that the tip of main branch gets verified.