### PR TITLE
Bump golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install golangci-lint
       run: |
-        curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.0
+        curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6
 
     - name: Verify
       run: make verify

--- a/cmd/blockio/main.go
+++ b/cmd/blockio/main.go
@@ -42,10 +42,10 @@ var examples string = `Examples:
 
 func usage() {
 	flag.CommandLine.SetOutput(os.Stdout)
-	fmt.Fprintln(flag.CommandLine.Output(), "blockio - demo application for goresctrl/pkg/blockio API")
-	fmt.Fprintln(flag.CommandLine.Output(), "Usage: blockio -config=FILE -class=NAME [-cgroup=CGROUP]")
+	fmt.Fprintln(flag.CommandLine.Output(), "blockio - demo application for goresctrl/pkg/blockio API") // nolint:errcheck
+	fmt.Fprintln(flag.CommandLine.Output(), "Usage: blockio -config=FILE -class=NAME [-cgroup=CGROUP]") // nolint:errcheck
 	flag.PrintDefaults()
-	fmt.Fprint(flag.CommandLine.Output(), examples)
+	fmt.Fprint(flag.CommandLine.Output(), examples) // nolint:errcheck
 }
 
 func errorExit(format string, args ...interface{}) {

--- a/cmd/sst-ctl/main.go
+++ b/cmd/sst-ctl/main.go
@@ -189,7 +189,7 @@ func getPackage(packageStr string, cpus utils.IDSet) (map[int]*sst.SstPackageInf
 	pkgs := str2slice(packageStr)
 	if len(pkgs) > 1 {
 		fmt.Printf("Only one package can be configured at a time (you have %d)\n", len(pkgs))
-		return nil, nil, nil, fmt.Errorf("Provide one package value only")
+		return nil, nil, nil, fmt.Errorf("provide one package value only")
 	}
 
 	if len(pkgs) == 0 {
@@ -216,7 +216,7 @@ func getPackage(packageStr string, cpus utils.IDSet) (map[int]*sst.SstPackageInf
 		for packageId, info = range infomap {
 			if !sst.CheckPackageCpus(info, cpus) {
 				fmt.Printf("All the CPUs %v must belong to one specific package\n", cpus)
-				return nil, nil, nil, fmt.Errorf("Not all CPUs belong to package %d", packageId)
+				return nil, nil, nil, fmt.Errorf("not all CPUs belong to package %d", packageId)
 			}
 
 			pkgs = append(pkgs, packageId)
@@ -288,7 +288,7 @@ func subCmdCP(args []string) error {
 	}
 
 	if enable && disable {
-		return fmt.Errorf("Please provide either -enable or -disable flag")
+		return fmt.Errorf("please provide either -enable or -disable flag")
 	}
 
 	// If user specifies a list of CPUs, then he/she wants to assign those
@@ -303,15 +303,15 @@ func subCmdCP(args []string) error {
 
 		infomap, info, pkgs, err = getPackage(packageIds, cpus)
 		if err != nil {
-			return fmt.Errorf("Cannot get CPUs %v package: %w", cpus, err)
+			return fmt.Errorf("cannot get CPUs %v package: %w", cpus, err)
 		}
 
 		if len(pkgs) == 0 {
-			return fmt.Errorf("All the CPUs %v must belong to one specific package", cpus)
+			return fmt.Errorf("all the CPUs %v must belong to one specific package", cpus)
 		}
 
 		if clos < 0 {
-			return fmt.Errorf("Clos not set, use -clos option")
+			return fmt.Errorf("CLOS not set, use -clos option")
 		}
 
 		cpu2Clos := make(sst.ClosCPUSet, 1)
@@ -324,7 +324,7 @@ func subCmdCP(args []string) error {
 	} else if clos >= 0 {
 		pkgs = str2slice(packageIds)
 		if len(pkgs) == 0 {
-			return fmt.Errorf("No packages set, invalid value %q", packageIds)
+			return fmt.Errorf("no packages set, invalid value %q", packageIds)
 		}
 
 		closinfo := sst.SstClosInfo{
@@ -337,17 +337,17 @@ func subCmdCP(args []string) error {
 
 		infomap, err = sst.GetPackageInfo(pkgs...)
 		if err != nil {
-			return fmt.Errorf("Cannot get package info: %w", err)
+			return fmt.Errorf("cannot get package info: %w", err)
 		}
 
 		for _, info = range infomap {
 			if err := sst.ClosSetup(info, clos, &closinfo); err != nil {
-				return fmt.Errorf("Cannot set Clos: %w", err)
+				return fmt.Errorf("cannot set Clos: %w", err)
 			}
 		}
 	} else {
 		if (!enable && !disable) && clos < 0 {
-			return fmt.Errorf("Clos not set, use -clos option")
+			return fmt.Errorf("CLOS not set, use -clos option")
 		}
 
 		// Print information if user just wants to enable / disable CP
@@ -357,14 +357,14 @@ func subCmdCP(args []string) error {
 	if enable || disable {
 		for packageId, info = range infomap {
 			if enable {
-				fmt.Printf("Enabling CP for package %d\n", packageId)
+				fmt.Printf("enabling CP for package %d\n", packageId)
 
 				err = sst.EnableCP(info)
 				if err != nil {
 					return err
 				}
 			} else if disable {
-				fmt.Printf("Disabling CP for package %d\n", packageId)
+				fmt.Printf("disabling CP for package %d\n", packageId)
 
 				err = sst.DisableCP(info)
 				if err != nil {

--- a/pkg/blockio/blockio_test.go
+++ b/pkg/blockio/blockio_test.go
@@ -52,9 +52,15 @@ func TestSetConfig(t *testing.T) {
 	badConfFile := testutils.CreateTempFile(t, "bad config contents.\n")
 	emptyConfFile := testutils.CreateTempFile(t, "")
 	goodConfFile := testutils.CreateTempFile(t, "Classes:\n  goodclass:\n")
-	defer os.Remove(badConfFile)
-	defer os.Remove(emptyConfFile)
-	defer os.Remove(goodConfFile)
+	rm := func(f string) {
+		if err := os.Remove(f); err != nil {
+			t.Logf("failed to remove temporary file %s: %v", f, err)
+		}
+	}
+	defer rm(badConfFile)
+	defer rm(emptyConfFile)
+	defer rm(goodConfFile)
+	t.Logf("failed to remove temporary file %s: %v", goodConfFile, err)
 
 	for syntaxerror := 0; syntaxerror < 4; syntaxerror++ {
 		classBlockIO, err = copyConf(initialConf), nil
@@ -359,21 +365,22 @@ type mockPlatform struct{}
 func (mpf mockPlatform) configurableBlockDevices(devWildcards []string) ([]tBlockDeviceInfo, error) {
 	blockDevices := []tBlockDeviceInfo{}
 	for _, devWildcard := range devWildcards {
-		if devWildcard == "/dev/sda" {
+		switch devWildcard {
+		case "/dev/sda":
 			blockDevices = append(blockDevices, tBlockDeviceInfo{
 				Major:   11,
 				Minor:   12,
 				DevNode: devWildcard,
 				Origin:  fmt.Sprintf("from wildcards %v", devWildcard),
 			})
-		} else if devWildcard == "/dev/sdb" {
+		case "/dev/sdb":
 			blockDevices = append(blockDevices, tBlockDeviceInfo{
 				Major:   21,
 				Minor:   22,
 				DevNode: devWildcard,
 				Origin:  fmt.Sprintf("from wildcards %v", devWildcard),
 			})
-		} else if devWildcard == "/dev/sdc" {
+		case "/dev/sdc":
 			blockDevices = append(blockDevices, tBlockDeviceInfo{
 				Major:   31,
 				Minor:   32,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -43,19 +43,19 @@ func NewLoggerWrapper(l *stdlog.Logger) Logger {
 }
 
 func (l *logger) Debugf(format string, v ...interface{}) {
-	l.Logger.Printf("DEBUG: "+format, v...)
+	l.Printf("DEBUG: "+format, v...)
 }
 
 func (l *logger) Infof(format string, v ...interface{}) {
-	l.Logger.Printf("INFO: "+format, v...)
+	l.Printf("INFO: "+format, v...)
 }
 
 func (l *logger) Warnf(format string, v ...interface{}) {
-	l.Logger.Printf("WARN: "+format, v...)
+	l.Printf("WARN: "+format, v...)
 }
 
 func (l *logger) Errorf(format string, v ...interface{}) {
-	l.Logger.Printf("ERROR: "+format, v...)
+	l.Printf("ERROR: "+format, v...)
 }
 
 func (l *logger) Panicf(format string, v ...interface{}) {

--- a/pkg/rdt/info.go
+++ b/pkg/rdt/info.go
@@ -299,7 +299,7 @@ func getResctrlMountInfo() (string, map[string]struct{}, error) {
 	if err != nil {
 		return "", mountOptions, err
 	}
-	defer f.Close()
+	defer f.Close() // nolint:errcheck
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {

--- a/pkg/rdt/rdt.go
+++ b/pkg/rdt/rdt.go
@@ -693,12 +693,16 @@ func (r *resctrlGroup) GetPids() ([]string, error) {
 	return []string{}, nil
 }
 
-func (r *resctrlGroup) AddPids(pids ...string) error {
+func (r *resctrlGroup) AddPids(pids ...string) (err error) {
 	f, err := os.OpenFile(r.path("tasks"), os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	for _, pid := range pids {
 		if _, err := f.WriteString(pid + "\n"); err != nil {
@@ -709,7 +713,7 @@ func (r *resctrlGroup) AddPids(pids ...string) error {
 			}
 		}
 	}
-	return nil
+	return
 }
 
 func (r *resctrlGroup) GetMonData() MonData {

--- a/pkg/rdt/rdt_test.go
+++ b/pkg/rdt/rdt_test.go
@@ -237,7 +237,11 @@ partitions:
 	}
 	// Configuration should fail as "Stale" class has pids assigned to it
 	testConfigFile := testutils.CreateTempFile(t, rdtTestConfig)
-	defer os.Remove(testConfigFile)
+	defer func() {
+		if err := os.Remove(testConfigFile); err != nil {
+			t.Logf("failed to remove temporary file %s: %v", testConfigFile, err)
+		}
+	}()
 	if err := SetConfigFromFile(testConfigFile, false); err == nil {
 		t.Fatalf("rdt configuration succeeded unexpetedly")
 	}

--- a/pkg/sst/sst.go
+++ b/pkg/sst/sst.go
@@ -364,7 +364,7 @@ func enableBF(info *SstPackageInfo) error {
 // EnableBF enables SST-BF and sets it up properly
 func EnableBF(pkgs ...int) error {
 	if ok, err := isHWPEnabled(); err != nil {
-		return fmt.Errorf("Failed to determine if HWP is enabled")
+		return fmt.Errorf("failed to determine if HWP is enabled")
 	} else if !ok {
 		return fmt.Errorf("HWP is not enabled")
 	}
@@ -518,7 +518,7 @@ func writeClosPmQosConfig(info *SstPackageInfo, cpu utils.ID, enable bool) error
 
 func enableCP(info *SstPackageInfo, cpu utils.ID) (uint32, error) {
 	if err := writeClosPmQosConfig(info, cpu, true); err != nil {
-		return 0, fmt.Errorf("Cannot set Clos status: %v", err)
+		return 0, fmt.Errorf("cannot set Clos status: %v", err)
 	}
 
 	return writePMConfig(info, cpu, true)
@@ -526,7 +526,7 @@ func enableCP(info *SstPackageInfo, cpu utils.ID) (uint32, error) {
 
 func disableCP(info *SstPackageInfo, cpu utils.ID) (uint32, error) {
 	if err := writeClosPmQosConfig(info, cpu, false); err != nil {
-		return 0, fmt.Errorf("Cannot set Clos status: %v", err)
+		return 0, fmt.Errorf("cannot set Clos status: %v", err)
 	}
 
 	return writePMConfig(info, cpu, false)
@@ -563,7 +563,7 @@ func ConfigureCP(info *SstPackageInfo, priority int, cpu2clos *ClosCPUSet) error
 	}
 
 	if priority < 0 || priority > 1 {
-		return fmt.Errorf("Invalid CP priority value %d (valid 0 or 1)", priority)
+		return fmt.Errorf("invalid CP priority value %d (valid 0 or 1)", priority)
 	}
 
 	if info.ClosCPUInfo == nil {
@@ -601,31 +601,31 @@ func ClosSetup(info *SstPackageInfo, clos int, closInfo *SstClosInfo) error {
 	}
 
 	if clos < 0 || clos >= NumClos {
-		return fmt.Errorf("Invalid Clos value (%d)", clos)
+		return fmt.Errorf("invalid Clos value (%d)", clos)
 	}
 
 	if closInfo.MinFreq < 0 || closInfo.MinFreq > 255 {
-		return fmt.Errorf("Invalid min freq (%d)", closInfo.MinFreq)
+		return fmt.Errorf("invalid min freq (%d)", closInfo.MinFreq)
 	}
 
 	if closInfo.MaxFreq < 0 || closInfo.MaxFreq > 255 {
-		return fmt.Errorf("Invalid max freq (%d)", closInfo.MaxFreq)
+		return fmt.Errorf("invalid max freq (%d)", closInfo.MaxFreq)
 	}
 
 	if closInfo.MinFreq > closInfo.MaxFreq {
-		return fmt.Errorf("Min freq %d must be smaller than max freq %d", closInfo.MinFreq, closInfo.MaxFreq)
+		return fmt.Errorf("min freq %d must be smaller than max freq %d", closInfo.MinFreq, closInfo.MaxFreq)
 	}
 
 	if closInfo.DesiredFreq < 0 || closInfo.DesiredFreq > 255 {
-		return fmt.Errorf("Invalid value %d for desired freq", closInfo.DesiredFreq)
+		return fmt.Errorf("invalid value %d for desired freq", closInfo.DesiredFreq)
 	}
 
 	if closInfo.EPP < 0 || closInfo.EPP > 15 {
-		return fmt.Errorf("Invalid value %d for EPP", closInfo.EPP)
+		return fmt.Errorf("invalid value %d for EPP", closInfo.EPP)
 	}
 
 	if closInfo.ProportionalPriority < 0 || closInfo.ProportionalPriority > 15 {
-		return fmt.Errorf("Invalid value %d for proportionalPriority", closInfo.ProportionalPriority)
+		return fmt.Errorf("invalid value %d for proportionalPriority", closInfo.ProportionalPriority)
 	}
 
 	info.ClosInfo[clos] = *closInfo
@@ -690,7 +690,7 @@ func DisableCP(info *SstPackageInfo) error {
 	}
 
 	if info.TFEnabled {
-		return fmt.Errorf("SST TF still enabled, disable it first.")
+		return fmt.Errorf("SST TF still enabled, disable it first")
 	}
 
 	rsp, err := disableCP(info, info.pkg.cpus[0])

--- a/pkg/sst/sst_if.go
+++ b/pkg/sst/sst_if.go
@@ -51,7 +51,7 @@ func isstIoctl(ioctl uintptr, req uintptr) error {
 	if err != nil {
 		return fmt.Errorf("failed to open isst device %q: %v", devPath, err)
 	}
-	defer f.Close()
+	defer f.Close() // nolint:errcheck
 
 	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(f.Fd()), ioctl, req); errno != 0 {
 		return errno
@@ -66,7 +66,7 @@ func isstIoctl(ioctl uintptr, req uintptr) error {
 // is based on APIC.
 func getCPUMapping(cpu utils.ID) (utils.ID, error) {
 	if cpu < 0 || cpu > math.MaxUint32 {
-		return utils.Unknown, fmt.Errorf("Invalid CPU number %d", cpu)
+		return utils.Unknown, fmt.Errorf("invalid CPU number %d", cpu)
 	}
 
 	req := isstIfCPUMaps{
@@ -86,7 +86,7 @@ func getCPUMapping(cpu utils.ID) (utils.ID, error) {
 // sendMboxCmd sends one mailbox command to PUNIT
 func sendMboxCmd(cpu utils.ID, cmd uint16, subCmd uint16, parameter uint32, reqData uint32) (uint32, error) {
 	if cpu < 0 || cpu > math.MaxUint32 {
-		return 0, fmt.Errorf("Invalid CPU number %d", cpu)
+		return 0, fmt.Errorf("invalid CPU number %d", cpu)
 	}
 
 	req := isstIfMboxCmds{
@@ -104,7 +104,7 @@ func sendMboxCmd(cpu utils.ID, cmd uint16, subCmd uint16, parameter uint32, reqD
 
 	sstlog.Debugf("MBOX SEND cpu: %d cmd: %#02x sub: %#02x data: %#x", cpu, cmd, subCmd, reqData)
 	if err := isstIoctl(ISST_IF_MBOX_COMMAND, uintptr(unsafe.Pointer(&req))); err != nil {
-		return 0, fmt.Errorf("Mbox command failed with %v", err)
+		return 0, fmt.Errorf("mbox command failed with %v", err)
 	}
 	sstlog.Debugf("MBOX RECV data: %#x", req.Mbox_cmd[0].Resp_data)
 
@@ -114,7 +114,7 @@ func sendMboxCmd(cpu utils.ID, cmd uint16, subCmd uint16, parameter uint32, reqD
 // sendMMIOCmd sends one MMIO command to PUNIT
 func sendMMIOCmd(cpu utils.ID, reg uint32, value uint32, doWrite bool) (uint32, error) {
 	if cpu < 0 || cpu > math.MaxUint32 {
-		return 0, fmt.Errorf("Invalid CPU number %d", cpu)
+		return 0, fmt.Errorf("invalid CPU number %d", cpu)
 	}
 
 	var ReadWrite uint32

--- a/pkg/utils/msr.go
+++ b/pkg/utils/msr.go
@@ -31,13 +31,13 @@ func ReadMSR(cpu ID, msr int64) (uint64, error) {
 		return 0, err
 	}
 
-	defer file.Close()
+	defer file.Close() // nolint:errcheck
 
 	// Whence is the point of reference for offset
 	// 0 = Beginning of file
 	// 1 = Current position
 	// 2 = End of file
-	var whence int = 0
+	whence := int(0)
 	_, err = file.Seek(msr, whence)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Fix numerous errors from the new linter:

- unchecked errors
- log: unnecessary embedded "Logger" fields
- error strings (should not be capitalized, should not end with punctuation or newlines)
- blockio test: use switch-case instead of if-else
- msr: should omit type int from declaration