### PR TITLE
cmd/rdt: add cmdline flag to control log level

### DIFF
--- a/cmd/rdt/main.go
+++ b/cmd/rdt/main.go
@@ -21,12 +21,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/http"
 	"os"
 	"slices"
 	"strings"
 
+	"github.com/intel/goresctrl/pkg/log"
 	"github.com/intel/goresctrl/pkg/rdt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -65,14 +67,19 @@ func main() {
 	flag.CommandLine.SetOutput(os.Stdout)
 	flag.Usage = usage
 
-	// Define the main help flag manually
+	// Parse global command line flags
 	help := flag.Bool("help", false, "Display this help")
+	logLevel := log.NewLevelFlag(slog.LevelDebug)
+	flag.Var(logLevel, "log-level", "Set log level (debug, info, warn, error)")
 	flag.Parse()
 
 	if *help {
 		flag.Usage()
 		os.Exit(0)
 	}
+
+	// Set log level
+	rdt.SetLogger(slog.New(log.NewLogHandler(logLevel)))
 
 	args := flag.Args()
 	if len(args) < 1 {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -17,8 +17,10 @@ limitations under the License.
 package log
 
 import (
+	"context"
 	"fmt"
 	stdlog "log"
+	"log/slog"
 	"strings"
 )
 
@@ -82,4 +84,71 @@ func DebugBlock(l Logger, heading, linePrefix, format string, v ...interface{}) 
 	for _, line := range lines {
 		l.Debugf("%s%s", linePrefix, line)
 	}
+}
+
+// Custom slog handler for changing the log level.
+type logHandler struct {
+	slog.Leveler
+	slog.Handler
+}
+
+// NewLogHandler creates a new slog handler that uses the provided log level
+// but otherwise clones the default slog handler.
+func NewLogHandler(level slog.Leveler) slog.Handler {
+	return &logHandler{
+		Leveler: level,
+		Handler: slog.Default().Handler(),
+	}
+}
+
+// Enabled implements the slog.Handler interface.
+func (h *logHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.Level()
+}
+
+// LevelFlag implement the flag.Value interface and can be used as a command
+// line flag for specifying the log level.
+type LevelFlag struct {
+	level slog.Level
+}
+
+func NewLevelFlag(level slog.Level) *LevelFlag {
+	return &LevelFlag{level: level}
+}
+
+// Set the log level.
+func (l *LevelFlag) Set(s string) error {
+	switch strings.ToLower(s) {
+	case "debug":
+		l.level = slog.LevelDebug
+	case "info":
+		l.level = slog.LevelInfo
+	case "warn":
+		l.level = slog.LevelWarn
+	case "error":
+		l.level = slog.LevelError
+	default:
+		return fmt.Errorf("must be one of: debug, info, warn, error")
+	}
+	return nil
+}
+
+// String returns the string representation of the log level.
+func (l *LevelFlag) String() string {
+	switch l.level {
+	case slog.LevelDebug:
+		return "debug"
+	case slog.LevelInfo:
+		return "info"
+	case slog.LevelWarn:
+		return "warn"
+	case slog.LevelError:
+		return "error"
+	default:
+		return fmt.Sprintf("level(%d)", l.level)
+	}
+}
+
+func (l *LevelFlag) Level() slog.Level {
+	return l.level
 }


### PR DESCRIPTION
Add common helpers to pkg/log that can be utilized in other cmds.