### PR TITLE
sst: fix legacy API

### DIFF
--- a/pkg/sst/fuzz_test.go
+++ b/pkg/sst/fuzz_test.go
@@ -87,8 +87,8 @@ func FuzzClosSetup(f *testing.F) {
 		if err != nil {
 			t.Fatalf("failed to get package info: %v", err)
 		}
-		if !cmp.Equal(updated[pkg].ClosStatus[clos], *expectedInfo) {
-			t.Errorf("CLOS not configured correctly, expected %v, got %v", expectedInfo, updated[pkg].ClosStatus[clos])
+		if !cmp.Equal(updated[pkg].ClosInfo[clos], *expectedInfo) {
+			t.Errorf("CLOS not configured correctly, expected %v, got %v", expectedInfo, updated[pkg].ClosInfo[clos])
 		}
 	})
 }

--- a/pkg/sst/legacy_api.go
+++ b/pkg/sst/legacy_api.go
@@ -55,7 +55,7 @@ type SstPackageInfo struct {
 	TFSupported bool
 	TFEnabled   bool
 
-	ClosStatus  [NumClos]SstClosInfo
+	ClosInfo    [NumClos]SstClosInfo
 	ClosCPUInfo ClosCPUSet
 }
 
@@ -318,7 +318,7 @@ func ClosSetup(info *SstPackageInfo, clos int, closInfo *SstClosInfo) error {
 		return fmt.Errorf("invalid value %d for proportionalPriority", closInfo.ProportionalPriority)
 	}
 
-	info.ClosStatus[clos] = *closInfo
+	info.ClosInfo[clos] = *closInfo
 
 	closConfig := ClosConfig{
 		ProportionalPriority: closInfo.ProportionalPriority,
@@ -459,7 +459,7 @@ func statusFromPackage(pkg *cpuPackageInfo, pi *PackageStatus) (*SstPackageInfo,
 		CPSupported:    primary.CP.Supported,
 		CPEnabled:      primary.CP.Enabled,
 		CPPriority:     primary.CP.Priority,
-		ClosStatus:     closInfos,
+		ClosInfo:       closInfos,
 		ClosCPUInfo:    make(ClosCPUSet),
 	}
 	if primary.BF.Cores != nil {


### PR DESCRIPTION
Fix one unfortunate inadvertent rename that happended when refactoring/moving the code while creating the new SST API.